### PR TITLE
test ci

### DIFF
--- a/src/cargo/core/compiler/job_queue/job_state.rs
+++ b/src/cargo/core/compiler/job_queue/job_state.rs
@@ -1,8 +1,10 @@
 //! See [`JobState`].
 
+use std::sync::mpsc;
 use std::{cell::Cell, marker, sync::Arc};
 
 use cargo_util::ProcessBuilder;
+use tracing::debug;
 
 use crate::core::compiler::future_incompat::FutureBreakageItem;
 use crate::core::compiler::locking::LockKey;
@@ -51,6 +53,13 @@ pub struct JobState<'a, 'gctx> {
     /// Manages locks for build units when fine grain locking is enabled.
     lock_manager: Arc<LockManager>,
 
+    /// If the job gets blocked for some reason (like waiting on a filesystem lock) we instruct the
+    /// job server to let other jobs proceed, effectively giving up our token.
+    /// Once we are unblocked, we want to wait for the job server to reschedule us while we keep
+    /// holding the lock. The scheduler will send an event over this mpsc channel when it
+    /// reschedules us.
+    resume: mpsc::Receiver<()>,
+
     // Historical versions of Cargo made use of the `'a` argument here, so to
     // leave the door open to future refactorings keep it here.
     _marker: marker::PhantomData<&'a ()>,
@@ -63,6 +72,7 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
         output: Option<&'a DiagDedupe<'gctx>>,
         rmeta_required: bool,
         lock_manager: Arc<LockManager>,
+        resume: mpsc::Receiver<()>,
     ) -> Self {
         Self {
             id,
@@ -70,6 +80,7 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
             output,
             rmeta_required: Cell::new(rmeta_required),
             lock_manager,
+            resume,
             _marker: marker::PhantomData,
         }
     }
@@ -148,7 +159,16 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
     }
 
     pub fn lock_exclusive(&self, lock: &LockKey) -> CargoResult<()> {
-        self.lock_manager.lock(lock)
+        let acquired = self.lock_manager.try_lock(lock)?;
+        if !acquired {
+            debug!(?lock, "Lock will block, suspending task");
+            self.messages.push(Message::Blocked(self.id));
+            self.lock_manager.lock(lock)?;
+            self.messages.push(Message::Unblocked(self.id));
+            self.resume.recv()?;
+        }
+
+        Ok(())
     }
 
     pub fn downgrade_to_shared(&self, lock: &LockKey) -> CargoResult<()> {


### PR DESCRIPTION
## Flow

* Before taking an exclusive lock (and potentially blocking) we do a [`.try_lock()` ](https://doc.rust-lang.org/std/fs/struct.File.html#method.try_lock) to see if we will block.
  * If we are going to block, we send a `Message::Blocked` letting the job queue reclaim the token for another job to run while we are blocked
  * If `try_lock` succeeds, we have the lock and never blocked, so we simply start compiling. 
* Once we acquire the lock, we sending a `Message::Unblocked` letting the job queue know we are ready to continue
* But before compiling, to respect the `--jobs` limit, wait for the job queue to reschedule us by calling `JobState.resume.recv()` which blocks the current thread.
* The job queue will eventually call `ActiveJob.resume.send()` which will let the job resume exection.

## Design

* We leverage the existing [`Queue<Message>`](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/job_queue/mod.rs#L176) in `JobState` to notify the job queue that we are going to block.
* For resuming tasks that are blocked, I used a `std::sync::mpsc::channel`. 

```mermaid
flowchart LR
    JQ["Job Queue (DrainState)"]
    J["Jobs"]

    J -- "Queue&lt;Message&gt;" --> JQ
    JQ -- "resume mpsc::channel" --> J
```

## Testing

To test this I found the easiest to way to do it synthetically by injecting a `std::thread::sleep` in the lock manager for a given lock. Along with passing `--jobs 1` to make a blocked job block the entire build.

```rs
pub fn lock(&self, key: &LockKey) -> CargoResult<()> {
      let locks = self.locks.read().unwrap();
      if key.0.to_str().unwrap().contains("libc") {
          std::thread::sleep(std::time::Duration::from_secs(5));
      }
      // ....
}
```


Test script
```sh
cargo new foo; cd foo; cargo add tokio --features full

rm -rf target build
alias lc=/path/to/cargo
CARGO_BUILD_BUILD_DIR=build lc -Zbuild-dir-new-layout -Zfine-grain-locking build --jobs 1
```

Doing this on `master` will result in blocked build that never completes, while changes in this PR will finish the build.



