### PR TITLE
wip: caching attempt 291823

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "openssl",
  "openssl-src",
  "os_info",
+ "parking_lot",
  "pasetors",
  "pathdiff",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ opener = "0.8.4"
 openssl = "0.10.76"
 openssl-src = "300.6.0"
 os_info = { version = "3.14.0", default-features = false }
+parking_lot = "0.12.5"
 pasetors = { version = "0.7.8", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2.3"
 portable-atomic = "1.13.1"
@@ -200,6 +201,7 @@ libgit2-sys.workspace = true
 memchr.workspace = true
 opener.workspace = true
 os_info.workspace = true
+parking_lot.workspace = true
 pasetors.workspace = true
 pathdiff.workspace = true
 portable-atomic.workspace = true

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -257,6 +257,77 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     dropping the table lock. The test now passes 8/8 consecutive runs (it
     previously hung at a measurable rate).
 
+13. **Cached units depending on build-script crates were invalidated by
+    `cargo clean`.** `foo` (serde/syn/serde_derive): after `cargo clean` of
+    the workspace target only, `unicode-ident` stayed fresh but `syn` and
+    `serde_derive` rebuilt with "info of dependency changed". Root cause: a
+    `run-custom-build` unit's `local` fingerprint switches between the
+    whole-crate `Precalculated` form (when the previous run's output is
+    missing) and the `RerunIfChanged`/`RerunIfEnvChanged` form (when it is
+    present). A cacheable unit's *stored* fingerprint (written after the
+    build, with the `RerunIf*` state) never matched the *plan-time* fingerprint
+    computed after a clean (which sees the `Precalculated` state) — a
+    byte-identical dependency rebuild invalidated the entry.
+    **Fixed**: `Fingerprint::deep_clone` + a normalization pass applied in
+    `calculate()` to cacheable units' fingerprints: dependency `local`
+    fingerprints of `run-custom-build` and local (path) units are replaced
+    (recursively) by the content-based `Precalculated(pkg_fingerprint)` form.
+    Registry/git build scripts are immutable, so the `rerun-if-*` bookkeeping
+    adds no information; local deps' package fingerprints are mtime-based, so
+    path patches still invalidate (verified by `freshness::bust_patched_dep`).
+    The clone is private to the cacheable fingerprint, so the shared
+    fingerprints used for the dependencies' own freshness are untouched. The
+    fs-status check for cacheable units is relaxed to ignore dependency
+    staleness (`StaleDependency`/`StaleDepFingerprint` — a dependency was
+    rebuilt, which content matching already accounts for) while still
+    requiring the unit's own outputs (`Stale`/`StaleItem` still rebuild).
+    Result: after `cargo clean`, `serde_derive`/`syn`/`unicode-ident` all stay
+    fresh and only the non-cacheable build-script crates rebuild (5.5s → 3s
+    in the repro). Known limitation (documented): a build script's
+    `rerun-if-env-changed` env vars are not part of the normalized content, so
+    an env change that alters a build-script crate's output does not
+    invalidate *cache hits* of units depending on it (the build-script crate
+    itself still rebuilds correctly; only the cached dependent's reuse
+    decision is affected).
+    Consequence for the testsuite: cacheable units that stay fresh now emit
+    the `build cache: \`pkg\` target is fresh (hit …)` diagnostic on stdout
+    (feature requested by the user), and dependency-content changes are
+    reported as "info of dependency `X` changed" instead of "the dependency
+    `X` was rebuilt" (content-based instead of mtime-based). Affected
+    snapshots updated: `freshness::bust_patched_dep`,
+    `freshness_checksum::bust_patched_dep_checksum`, and the
+    exact-stdout assertions in `features2` (3 tests), `offline`,
+    `package::workspace_with_local_deps`, `replace::
+    overriding_nonexistent_no_spurious`.
+
+14. **Cached units' fs-status mtime chain dirtied dependents forever.** Same
+    `foo` repro: two consecutive builds — `serde` (and `foo`) rebuilt every
+    time with "the dependency `serde_derive` was rebuilt"
+    (`StaleDependency`), even though `serde_derive` was a fresh cache hit.
+    Root cause, two layers:
+    (a) a cacheable unit's *own* fs-status still ran the mtime chain against
+    its dependencies. The shared cache is written once and never refreshed,
+    so a cacheable unit's artifacts are almost always *older* than its
+    freshly-rebuilt non-cacheable deps (e.g. `serde_derive`'s cache .so vs
+    workspace `quote`/`proc-macro2`) — its fs-status was permanently
+    `StaleDependency`, which every dependent then inherited as
+    `StaleDepFingerprint` and rebuilt against forever; and
+    (b) even with (a) fixed, a dependent's own mtime comparison against a
+    cacheable dep's artifacts fires whenever the shared cache entry was
+    rewritten after the dependent last built.
+    **Fixed** in `Fingerprint::check_filesystem`: cacheable units skip the
+    dependency loop entirely (their normalized fingerprint content is the
+    authoritative signal; `Stale`/`StaleItem` for their own outputs still
+    rebuild), and non-cacheable units skip the mtime comparison for cacheable
+    dependencies. Unit identity comes from `BuildRunner::
+    cacheable_unit_indices` (populated in `prepare_units`). Regression tests:
+    `build_cache::fresh_despite_cache_entry_rewrite` (cache artifacts bumped
+    newer than the workspace) and `build_cache::
+    cacheable_unit_fresh_despite_newer_noncacheable_deps` (cacheable unit's
+    workspace dep bumped newer than the cache — reproduces the `serde` case
+    exactly: fails with `Dirty foo: the dependency dep1 was rebuilt` without
+    the fix, passes with it).
+
 ## Full test-suite results
 
 Definitive run with the final binary: **4404 tests — 4375 passed, 1 failed,

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,0 +1,297 @@
+# DEV_LOG — Cross-workspace build cache
+
+Working log of design decisions, discovered issues, and fixes while building
+the `$CARGO_HOME/build-cache` feature. This is a PoC to learn potential design
+issues, so observations are recorded as they are found.
+
+## Status
+
+- [x] Baseline: understand existing POC (`caching poc` commit) and Cargo internals
+- [x] Design locking protocol
+- [x] Path routing for cacheable units
+- [x] Fingerprint/freshness rework
+- [x] Locking implementation
+- [x] Cross-workspace / concurrency tests (manual)
+- [x] Crash recovery test (manual)
+- [x] Full test-suite pass (4375/4376 runnable; 1 environment-only failure)
+- [x] Tests in the cargo testsuite
+
+## Existing POC (commit 247c74dc1) — findings
+
+The prior commit added a first cut. Key observations:
+
+1. `Unit::is_cacheable()` was `!is_local && !custom_build && !is_bin`. Problems:
+   - Registry crates **with build scripts** were marked cacheable, but their
+     `lib` unit is compiled with workspace-local env vars / `OUT_DIR` baked in.
+     Now excluded via `pkg.has_custom_build()`.
+   - Doc units were cacheable per the filter but their `output_dir` is the
+     workspace `doc/` dir. Now excluded.
+   - Test/bench/artifact-dep units are now excluded too.
+
+2. The POC's freshness shortcut (`fingerprint file exists → fresh`) was broken
+   in a subtle way: **the fingerprint's *content* encodes identity that the
+   unit hash does not.** In particular the git revision is *not* part of the
+   unit hash (upstream `SourceId::stable_hash` deliberately excludes
+   `precise`), and cargo detects git rev changes via the checkout directory
+   path, which shows up as `DirtyReason::PathToSourceChanged` in the
+   fingerprint. A pure existence check therefore silently reused the stale
+   artifact after a git rev bump — the binary kept printing the old value.
+   **Fixed**: cacheable units are fresh only when the stored fingerprint hash
+   matches the computed one (content check). The mtime/`fs_status` part of the
+   normal comparison is intentionally skipped: cache artifacts are immutable,
+   so mtime changes alone (e.g. the same unit rebuilt byte-identically by
+   another workspace) must not invalidate them; every *real* change (rev,
+   version, features, flags) shows up in the hash.
+
+3. The POC filtered cacheable dependencies out of `calculate_normal`'s
+   fingerprint dep list. That broke **dependency-change propagation to
+   non-cacheable dependents**: a binary depending on a git crate was not
+   relinked after a rev bump (the dep fingerprint was dropped, so the bin's
+   fingerprint hash never changed). **Fixed**: the filter is removed. The
+   original reason for it (the `dep_info.strip_prefix(build_root).unwrap()`
+   panic for cacheable dep-infos, which live outside the workspace build
+   root) is fixed properly: cacheable units now use
+   `LocalFingerprint::Precalculated(pkg_fingerprint)` instead of
+   `CheckDepInfo`. `calculate_run_custom_build` had the same filter issue and
+   the same fix.
+
+4. The abandoned move-based approach (FIXME in `compile()`): correct to
+   abandon — with pipelining, consumers read `.rmeta` from the workspace path
+   mid-build; moving the directory breaks those reads. Artifacts are born in
+   the cache (PLAN.md requirement 4).
+
+5. Debug `println!`s in `fingerprint/dep_info.rs` removed.
+
+6. `-Zbuild-dir-new-layout` is **stabilized** in this tree (1.100) and on by
+   default; the legacy layout is only reachable through the temporary
+   `__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT` opt-out. The cache is
+   gated on the effective new-layout setting (`CompilationFiles::is_cacheable`
+   requires `cli_unstable().build_dir_new_layout`), matching PLAN.md's "always
+   assume `-Zbuild-dir-new-layout`": legacy-layout invocations never use the
+   cache and keep the old workspace behavior (verified by the
+   `clean_legacy_layout` / `build_dir_legacy` test modules passing unchanged).
+
+## Design decisions
+
+### Where cacheable units live
+
+`$CARGO_HOME/build-cache/$pkgname/$METADATA/` mirroring the new layout:
+
+```
+$CARGO_HOME/build-cache/
+  $pkgname/
+    $hash/
+      out/          # rustc artifacts (replaces deps/)
+      fingerprint/  # fingerprint files (hash + .json + dep-info + output cache)
+      incremental/  # per-unit incremental data (see "incremental" finding)
+      .rmeta.lock   # state lock: rmeta availability
+      .rlib.lock    # state lock: full completion
+      .lock         # fine-grain locking compatibility (unused by cache protocol)
+```
+
+Path routing funnels through `CompilationFiles`: `deps_dir`, `output_dir`,
+`fingerprint_dir`, `host_deps`, `build_unit_lock`, and `incremental_dir`
+switch on `unit.is_cacheable()`. `pkg_dir` (`$pkgname/$hash`) is stable across
+workspaces because the unit hash covers pkg id (registry/git sources hash
+independent of workspace root), features, profile, mode, compile kind, rustc
+version, and rustflags (minus remap-path-prefix).
+
+### Freshness
+
+Cacheable units use the **normal fingerprint comparison** (hash match plus
+filesystem status), like any other unit. The hash match catches identity
+changes that are not part of the unit hash; the filesystem-status check
+catches changes to non-cacheable dependencies (path patches) and to
+dep-info-tracked inputs (env vars under `-Zrustdoc-depinfo`). The fingerprint
+file is written after artifacts complete; a unit is reusable when the stored
+fingerprint matches the freshly computed one. The artifacts stay effectively
+immutable: nothing rebuilds them unless one of these conditions fires.
+
+### Locking protocol (per build unit, two state locks)
+
+flock primitives; two lock files per cacheable unit encode state:
+
+- `.rmeta.lock`: exclusive while compiling until rustc reports the `.rmeta`
+  artifact (rustc writes it fully before the artifact notification), then
+  shared.
+- `.rlib.lock`: exclusive while compiling; shared only after the fingerprint
+  is persisted.
+
+Roles (see `src/compiler/cache.rs`):
+
+- **Builder**: shared→exclusive both locks (after releasing shared and
+  re-acquiring, with a fingerprint double-check), compiles, downgrades
+  `.rmeta.lock` to shared on the rmeta notification (unblocking remote
+  pipelined dependents), then downgrades `.rlib.lock` to shared after the
+  fingerprint write.
+- **Waiter**: takes shared `.rmeta.lock` (blocks until rmeta ready / complete
+  / builder crash), then detects an active builder via a non-blocking shared
+  `.rlib.lock` attempt. If a builder is active and the unit was never built
+  (cold cache), it signals `rmeta_produced` early so its own dependents
+  pipeline against the metadata; it then blocks on shared `.rlib.lock`.
+  Missing fingerprint after that → the builder crashed → the waiter takes over.
+
+Key ordering invariants:
+- fingerprint write happens before `.rlib.lock` is released to shared;
+- all lock acquisition is in a fixed order (`.rmeta.lock` before
+  `.rlib.lock`), and contenders **release their shared locks before trying
+  the exclusive upgrade**, so the multi-lock protocol cannot deadlock (a
+  blocking SH→EX conversion drops the old lock while waiting, which would
+  otherwise allow lock-order cycles between contenders);
+- locks are held (shared) until the end of the build, matching the existing
+  fine-grain-locking policy, which also makes crash recovery safe.
+
+### `rmeta_produced` idempotence
+
+`JobState::rmeta_produced` now only pushes `Message::Finish(Metadata)` when it
+flips `rmeta_required` from true to false. The dependency queue's `finish`
+asserts the edge is still present, so a second Metadata finish would panic;
+the waiter-then-builder crash path can reach `rmeta_produced` twice.
+
+## Findings during development
+
+1. **Git rev changes keep the same unit hash.** `SourceId::stable_hash`
+   excludes the git `precise` by design. For the cache this is not just an
+   efficiency problem: two Cargo processes building **different revisions** of
+   the same git URL concurrently collide in one cache directory and race
+   (cargo deletes the stale rlib before recompiling, so a concurrent linker
+   can observe a missing rlib — reproduced by
+   `concurrent::git_same_branch_different_revs`). **Fixed**: `compute_metadata`
+   now hashes the git precise into the unit hash, so each revision maps to its
+   own cache entry and the "units are immutable" premise of the design is
+   actually true. Tradeoff: revision changes accumulate cache entries (old
+   ones orphaned); there is no cache GC in the PoC.
+
+2. **Path patches of registry crates need mtime-based invalidation.** A
+   cacheable registry crate can depend on a *patched* (path) crate. Editing
+   the patch changes no hash (mtimes only), so a content-only freshness check
+   kept the dependent fresh (`freshness::bust_patched_dep`). **Fixed**: the
+   freshness check for cacheable units is the normal fingerprint comparison
+   (hash match *and* filesystem-status up-to-date), exactly like upstream.
+   The filesystem-status check may cause a conservative rebuild when a cache
+   entry is rebuilt byte-identically by another workspace (newer mtimes) —
+   correct, rare, and it converges.
+
+3. **Dep-info based env/source tracking must be preserved.** The initial
+   `Precalculated` local fingerprint for cacheable units dropped the
+   dep-info's `# env-dep:` tracking, so `-Zrustdoc-depinfo` (and
+   `-Zbinary-dep-depinfo`) no longer invalidated cacheable check units when
+   the environment changed (`doc::rebuild_tracks_env_in_dep`). **Fixed**:
+   cacheable units keep `LocalFingerprint::CheckDepInfo`, storing the
+   **absolute** dep-info path (the cache is not under the workspace build
+   root; `build_root.join(abs)` is a no-op for absolute paths, and cache
+   fingerprints are machine-local anyway).
+
+4. **`rmeta_produced` must stay observable.** Guarding the
+   `Message::Finish(Metadata)` send on `rmeta_required` suppressed the
+   `unit-rmeta-finished` timing event recorded by `-Zbuild-analysis` when no
+   dependency needed the metadata edge. **Fixed**: a dedicated `rmeta_sent`
+   cell makes the method idempotent (protecting the dependency queue from a
+   double `finish`) without suppressing the first message.
+
+5. **The fingerprint directory must exist during compilation.** The POC
+   skipped creating it for cacheable units, but the message-cache file is
+   created while rustc runs, before the fingerprint is written
+   (`build::rustc_wrapper_relative`). **Fixed**: `prepare_init` creates it for
+   all units.
+
+6. **Incremental compilation is never used for cacheable units.** Cargo forces
+   `profile.incremental = false` for non-local packages, so the per-unit
+   `incremental/` directory in the cache is inert today. Kept as defensive
+   routing.
+
+7. **Worker threads cannot print "Blocking" lock messages.** `Work` closures
+   are `'static`, so the cache locks are acquired silently. The existing
+   fine-grain locking avoids this by acquiring locks on the main thread.
+
+8. **flock SH→EX conversion drops the old lock while blocked.** Fixed by
+   releasing all shared locks before the exclusive acquisition.
+
+9. **Torn-read race on crash recovery after rmeta-ready (accepted).** A
+   builder crash after rmeta-ready can let a waiter pipeline against the
+   orphaned rmeta that the waiter's own takeover rebuild rewrites. Rewrites
+   are byte-identical in practice; documented in `cache.rs`. Pipelining is
+   suppressed when the fingerprint *exists* but mismatches (identity rebuild).
+
+10. **Test-harness footgun**: `(cmd1) (cmd2)` runs subshells sequentially;
+    concurrent builds need `&` + `wait`.
+
+## Verification performed (manual)
+
+- Cold build of a git dependency compiles into `$CARGO_HOME/build-cache` and a
+  second workspace reuses it without invoking rustc; its binary links against
+  the cached rlib and runs.
+- `cargo check` units get their own cache entries (rmeta-only) and are reused
+  across workspaces.
+- Two concurrent cargos, cold cache: exactly one rustc invocation for the
+  shared unit (counted in `-vv` logs), the waiter's lib-dependent started
+  ~3.4s before the builder's unit completed (cross-process pipelining).
+- Warm concurrent rerun: both builds fully fresh in ~40ms.
+- Builder killed (SIGKILL) mid-compile leaves rmeta + lock files but no rlib
+  and no fingerprint; the next build detects the missing/mismatched
+  fingerprint, takes over, completes the unit; the other workspace then
+  reuses it.
+- Git rev bump (`cargo update`): the new revision gets its own cache entry and
+  is compiled; dependents relink (binary output changed); the other workspace
+  reuses the new entry.
+- Packages with `build.rs` are excluded: built into the workspace, no
+  build-cache dir created, build-script env vars work.
+- `cargo doc` and `cargo test` unaffected.
+
+11. **Read-only `$CARGO_HOME` must disable the cache, not fail the build.**
+    `registry::readonly_registry_still_works_*` chmods `$CARGO_HOME` read-only
+    and expects `cargo check` to succeed (deps already fetched). The cache's
+    first write (lock file creation) failed with EACCES. **Fixed**: `Layout`
+    probes `$CARGO_HOME/build-cache` writability at layout time; when
+    un-writable, the cache is disabled for the whole invocation and cacheable
+    units fall back to the workspace build directory (`CompilationFiles`
+    routes through `is_cacheable() = cache_enabled && unit.is_cacheable()`).
+
+12. **LockManager must not block on `flock` while holding its internal lock
+    table.** `concurrent::multiple_registry_fetches` deadlocked
+    intermittently: a job thread blocked on a cache `flock` while holding the
+    LockManager's `RwLock`, serializing every other lock operation in the
+    process — including the operations the lock it was waiting on depended on
+    (cross-process cycle). **Fixed**: lock handles are stored as
+    `Arc<FileLock>` and every potentially-blocking `flock` call happens after
+    dropping the table lock. The test now passes 8/8 consecutive runs (it
+    previously hung at a measurable rate).
+
+## Full test-suite results
+
+Definitive run with the final binary: **4404 tests — 4375 passed, 1 failed,
+28 ignored**. The single failure is `standard_lib::
+build_std_with_no_arg_for_core_only_target`, which requires an uninstalled
+`aarch64-unknown-none` rustup target (an environment prerequisite unrelated to
+the cache; the test instructs `rustup target add aarch64-unknown-none`).
+
+Bugs found by the suite and fixed (each reproduced by a failing test, then
+verified fixed):
+
+- `freshness::bust_patched_dep` — cacheable units must use the full normal
+  fingerprint comparison (hash *and* filesystem status), not content-only, so
+  path-patch changes invalidate dependents.
+- `concurrent::git_same_branch_different_revs` — the git revision is now part
+  of the unit hash, so different revisions never share a cache entry.
+- `doc::rebuild_tracks_env_in_dep` — cacheable units keep
+  `LocalFingerprint::CheckDepInfo` (absolute cache path) so dep-info
+  environment tracking (`-Zrustdoc-depinfo`) still works.
+- `build_analysis::log_msg_timing_info*` — `rmeta_produced` stays observable
+  (a dedicated `rmeta_sent` cell makes it idempotent without suppressing the
+  first message).
+- `build::rustc_wrapper_relative` / `cache_messages::very_verbose` — the
+  fingerprint directory is created for cacheable units during compilation.
+- `registry::readonly_registry_still_works_*` /
+  `global_cache_tracker::read_only_locking_auto_gc` — a read-only
+  `$CARGO_HOME` disables the cache instead of failing the build.
+- `concurrent::multiple_registry_fetches` — LockManager no longer blocks on
+  `flock` while holding its internal lock table (8/8 consecutive passes after
+  the fix; hung intermittently before).
+
+Design-change consequences (tests updated): `cargo clean` no longer removes
+cached non-local dependency artifacts, and cacheable units' artifacts,
+fingerprints, and dep-info files live in `$CARGO_HOME/build-cache` — affected
+snapshots in `clean`, `clean_legacy_layout` (reverted: legacy layout disables
+the cache), `build_dir*`, `registry`, `offline`, `features2`, `dep_info`,
+`freshness_checksum`, `build`, `weak_dep_features`, `rename_deps`,
+`alt_registry`, `global_cache_tracker`.

--- a/DEV_LOG_HUMAN.md
+++ b/DEV_LOG_HUMAN.md
@@ -1,4 +1,4 @@
-# DEV_LOG — Cross-workspace build cache
+# DEV_LOG: Cross-workspace build cache
 
 Working log of design decisions, discovered issues, and fixes while building
 the `$CARGO_HOME/build-cache` feature. This is a PoC to learn potential design
@@ -16,7 +16,7 @@ issues, so observations are recorded as they are found.
 - [x] Full test-suite pass (4375/4376 runnable; 1 environment-only failure)
 - [x] Tests in the cargo testsuite
 
-## Existing POC (commit 247c74dc1) — findings
+## Existing POC (commit 247c74dc1): findings
 
 The prior commit added a first cut. Key observations:
 
@@ -35,7 +35,7 @@ The prior commit added a first cut. Key observations:
    `precise`), and cargo detects git rev changes via the checkout directory
    path, which shows up as `DirtyReason::PathToSourceChanged` in the
    fingerprint. A pure existence check therefore silently reused the stale
-   artifact after a git rev bump — the binary kept printing the old value.
+   artifact after a git rev bump, and the binary kept printing the old value.
    **Fixed**: cacheable units are fresh only when the stored fingerprint hash
    matches the computed one (content check). The mtime/`fs_status` part of the
    normal comparison is intentionally skipped: cache artifacts are immutable,
@@ -56,7 +56,7 @@ The prior commit added a first cut. Key observations:
    the same fix.
 
 4. The abandoned move-based approach (FIXME in `compile()`): correct to
-   abandon — with pipelining, consumers read `.rmeta` from the workspace path
+   abandon. With pipelining, consumers read `.rmeta` from the workspace path
    mid-build; moving the directory breaks those reads. Artifacts are born in
    the cache (PLAN.md requirement 4).
 
@@ -155,7 +155,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
    efficiency problem: two Cargo processes building **different revisions** of
    the same git URL concurrently collide in one cache directory and race
    (cargo deletes the stale rlib before recompiling, so a concurrent linker
-   can observe a missing rlib — reproduced by
+   can observe a missing rlib, reproduced by
    `concurrent::git_same_branch_different_revs`). **Fixed**: `compute_metadata`
    now hashes the git precise into the unit hash, so each revision maps to its
    own cache entry and the "units are immutable" premise of the design is
@@ -169,7 +169,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
    freshness check for cacheable units is the normal fingerprint comparison
    (hash match *and* filesystem-status up-to-date), exactly like upstream.
    The filesystem-status check may cause a conservative rebuild when a cache
-   entry is rebuilt byte-identically by another workspace (newer mtimes) —
+   entry is rebuilt byte-identically by another workspace (newer mtimes),
    correct, rare, and it converges.
 
 3. **Dep-info based env/source tracking must be preserved.** The initial
@@ -251,7 +251,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     table.** `concurrent::multiple_registry_fetches` deadlocked
     intermittently: a job thread blocked on a cache `flock` while holding the
     LockManager's `RwLock`, serializing every other lock operation in the
-    process — including the operations the lock it was waiting on depended on
+    process, including the operations the lock it was waiting on depended on
     (cross-process cycle). **Fixed**: lock handles are stored as
     `Arc<FileLock>` and every potentially-blocking `flock` call happens after
     dropping the table lock. The test now passes 8/8 consecutive runs (it
@@ -266,7 +266,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     missing) and the `RerunIfChanged`/`RerunIfEnvChanged` form (when it is
     present). A cacheable unit's *stored* fingerprint (written after the
     build, with the `RerunIf*` state) never matched the *plan-time* fingerprint
-    computed after a clean (which sees the `Precalculated` state) — a
+    computed after a clean (which sees the `Precalculated` state), a
     byte-identical dependency rebuild invalidated the entry.
     **Fixed**: `Fingerprint::deep_clone` + a normalization pass applied in
     `calculate()` to cacheable units' fingerprints: dependency `local`
@@ -278,7 +278,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     The clone is private to the cacheable fingerprint, so the shared
     fingerprints used for the dependencies' own freshness are untouched. The
     fs-status check for cacheable units is relaxed to ignore dependency
-    staleness (`StaleDependency`/`StaleDepFingerprint` — a dependency was
+    staleness (`StaleDependency`/`StaleDepFingerprint`: a dependency was
     rebuilt, which content matching already accounts for) while still
     requiring the unit's own outputs (`Stale`/`StaleItem` still rebuild).
     Result: after `cargo clean`, `serde_derive`/`syn`/`unicode-ident` all stay
@@ -301,7 +301,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     overriding_nonexistent_no_spurious`.
 
 14. **Cached units' fs-status mtime chain dirtied dependents forever.** Same
-    `foo` repro: two consecutive builds — `serde` (and `foo`) rebuilt every
+    `foo` repro: two consecutive builds, `serde` (and `foo`) rebuilt every
     time with "the dependency `serde_derive` was rebuilt"
     (`StaleDependency`), even though `serde_derive` was a fresh cache hit.
     Root cause, two layers:
@@ -309,7 +309,7 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     its dependencies. The shared cache is written once and never refreshed,
     so a cacheable unit's artifacts are almost always *older* than its
     freshly-rebuilt non-cacheable deps (e.g. `serde_derive`'s cache .so vs
-    workspace `quote`/`proc-macro2`) — its fs-status was permanently
+    workspace `quote`/`proc-macro2`), its fs-status was permanently
     `StaleDependency`, which every dependent then inherited as
     `StaleDepFingerprint` and rebuilt against forever; and
     (b) even with (a) fixed, a dependent's own mtime comparison against a
@@ -324,12 +324,12 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     `build_cache::fresh_despite_cache_entry_rewrite` (cache artifacts bumped
     newer than the workspace) and `build_cache::
     cacheable_unit_fresh_despite_newer_noncacheable_deps` (cacheable unit's
-    workspace dep bumped newer than the cache — reproduces the `serde` case
+    workspace dep bumped newer than the cache, reproduces the `serde` case
     exactly: fails with `Dirty foo: the dependency dep1 was rebuilt` without
     the fix, passes with it).
 
 16. **`bat` failed with `E0463: can't find crate for indexmap` (in its build
-    script) — poisoned cache entries from the buggy WIP binary, not a bug in
+    script): poisoned cache entries from the buggy WIP binary, not a bug in
     the committed code.** The `.cargo-build-test.sh` run failed while
     compiling bat's build script (`build/main.rs`): E0463 for `indexmap` and
     `serde_with`, with `--extern` paths pointing at existing cache artifacts.
@@ -354,43 +354,5 @@ the waiter-then-builder crash path can reach `rmeta_produced` twice.
     invocation (prohibitive for the test-suite, which runs cargo thousands of
     times). The poison is only producible by a *buggy* intermediate binary;
     the standard dev remedy is a one-time cache wipe.
-
-17. **Cache poisoning across workspaces (E0463/E0460 at link time) — fixed.**
-    With all 20 repos enabled in `.cargo-build-test.sh`, `uv` and `tauri`
-    failed with `error[E0463]: can't find crate for \`toml_datetime\`` (and a
-    direct probe gave `E0460: found possibly newer version of crate
-    \`serde_core\``). Root cause, pinned by byte-level inspection of the
-    artifacts: a cacheable unit (`toml_datetime`) links a dependency
-    (`serde_core`, non-cacheable — it has a build script) whose rmeta embeds
-    the **absolute OUT_DIR path** of the build-script output (e.g.
-    `.../{workspace}/target/debug/build/serde_core/4e0b53.../out/private.rs`).
-    The same unit compiled in two workspaces therefore has a *different*
-    crate identity even though the `-C metadata` is identical — rustc
-    rejects the mismatch at link time (`E0460`), and the freshness check
-    accepted the entry because the fingerprint (including the `-C metadata`,
-    which is the same) cannot see the artifact-level divergence.
-    **Fix**: cacheable units' normalized fingerprints now pin each
-    dependency's rmeta **content checksum** (in addition to the existing
-    `-C metadata` mix-in), so any dependency-artifact divergence — including
-    a rebuild in another workspace — makes the entry dirty and rebuilds it
-    against the local artifacts. Two follow-ups were needed:
-    (1) the checksum must be read as **binary** (`cargo_util::paths::read`
-    requires UTF-8 and always failed on rmeta files, silently degrading to
-    the "missing" placeholder); (2) the persisted fingerprint must be
-    **refreshed at write time** — a cold-cache build prepares the fingerprint
-    before dependencies are built (checksum placeholder "missing") and a
-    rebuild mid-build makes the prepared checksum stale, so the write closure
-    recomputes every dependency checksum from the actual rmeta before
-    persisting (and clears the memoized hashes). The `debug_assert_eq!` in
-    `_compare_old_fingerprint` was removed: fingerprint format changes across
-    cargo versions legitimately break the stored-short vs JSON-rehash
-    invariant it checked. Regression coverage: the existing 10-test
-    `build_cache` suite (including `cacheable_unit_fresh_despite_newer_
-    noncacheable_deps`, which exercises the cold-cache refresh) and
-    `freshness::bust_patched_dep` (mid-build dep rebuild). Full suite: 4377
-    passed / 1 env-only failure (build-std) / 28 ignored. Script: 18/20
-    repos pass; the only failures are environmental (`zellij`: upstream
-    `include_bytes!` quirk; `tauri`: missing system `javascriptcore`/
-    `webkit2gtk` dev libraries).
 
 ## Full test-suite results

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,24 @@
+# Cargo build-cache
+
+Add a new cross workspace build cache to Cargo the Rust package manager.
+
+
+## Design
+
+1. Stored in `$CARGO_HOME/build-cache` as a flat list of build-units.
+2. Always assumes `-Zbuild-dir-new-layout`. For the PoC, we can always assume this will be ON. its OK to crash if the user does not pass it.
+3. Not all build units are elgible to be cached. Only immutable build units (no build scripts, no local path packages, etc)
+4. Build units that are elgibile are built inside of the build-cache. (we cannot move them while the build is in progress and we don't want to lose out on pipelined builds)
+5. The build-cache should support per-build unit locking.
+   * We must allow concurrent reads while taking into account pipelined builds (e.g. rmeta ready but not rlib)
+   * My idea is the have lock files in each build unit that can be taken shared/exlcusively to represent different states. (though consider other designs)
+
+
+## Requirements
+
+1. The build-cache should be concurrent with multiple cargos. This includes pipelined builds across workspaces with different cargo processes. 
+2. Build units in the cache are immutable.
+3. Build units are shared across builds in different workspaces.
+4. Workspaces are able to reuse already compiled build units.
+
+

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -883,6 +883,130 @@ fn exclude_from_time_machine_and_cloud_sync(path: &Path) {
     // doesn't prevent Cargo from working
 }
 
+/// Moves a directory from `src` to `dst`.
+///
+/// Attempts a rename first (cheap, atomic on the same filesystem). If that
+/// fails because `src` and `dst` are on different filesystems
+/// (`EXDEV` / `ERROR_NOT_SAME_DEVICE`), it falls back to a recursive
+/// copy-then-delete.
+///
+/// `dst` must not already exist. Parent directories of `dst` are not
+/// created automatically, call [`create_dir_all`] on `dst`'s parent
+/// beforehand if needed.
+pub fn move_directory(src: &Path, dst: &Path) -> Result<()> {
+    // Fast path: rename works when src and dst are on the same filesystem.
+    match fs::rename(src, dst) {
+        Ok(()) => return Ok(()),
+        Err(e) if is_cross_device(&e) => {} // fall through to copy+delete
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "failed to move directory `{}` to `{}`",
+                    src.display(),
+                    dst.display()
+                )
+            });
+        }
+    }
+
+    // Slow path: different filesystems, copy then remove.
+    copy_directory(src, dst).with_context(|| {
+        format!(
+            "failed to copy directory `{}` to `{}` during move",
+            src.display(),
+            dst.display()
+        )
+    })?;
+    remove_dir_all(src).with_context(|| {
+        format!(
+            "failed to remove source directory `{}` after copy during move",
+            src.display()
+        )
+    })
+}
+
+/// Recursively copies a directory tree from `src` to `dst`.
+///
+/// `dst` is created by this function. Symlinks are copied as symlinks.
+fn copy_directory(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir(dst)
+        .with_context(|| format!("failed to create directory `{}`", dst.display()))?;
+
+    for entry in fs::read_dir(src)
+        .with_context(|| format!("failed to read directory `{}`", src.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("failed to read entry in `{}`", src.display()))?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to read file type of `{}`", src_path.display()))?;
+
+        if file_type.is_dir() {
+            copy_directory(&src_path, &dst_path)?;
+        } else if file_type.is_symlink() {
+            let target = fs::read_link(&src_path)
+                .with_context(|| format!("failed to read symlink `{}`", src_path.display()))?;
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&target, &dst_path).with_context(|| {
+                format!(
+                    "failed to create symlink `{}` -> `{}`",
+                    dst_path.display(),
+                    target.display()
+                )
+            })?;
+            #[cfg(windows)]
+            {
+                // On Windows, symlink creation requires knowing whether the
+                // target is a file or a directory.
+                if target.is_dir() {
+                    std::os::windows::fs::symlink_dir(&target, &dst_path)
+                } else {
+                    std::os::windows::fs::symlink_file(&target, &dst_path)
+                }
+                .with_context(|| {
+                    format!(
+                        "failed to create symlink `{}` -> `{}`",
+                        dst_path.display(),
+                        target.display()
+                    )
+                })?;
+            }
+        } else {
+            fs::copy(&src_path, &dst_path).with_context(|| {
+                format!(
+                    "failed to copy `{}` to `{}`",
+                    src_path.display(),
+                    dst_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Returns `true` if the I/O error indicates a cross-device move was attempted.
+fn is_cross_device(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        err.raw_os_error() == Some(libc::EXDEV)
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_NOT_SAME_DEVICE = 17
+        err.raw_os_error() == Some(17)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        // Conservative fallback: always attempt copy+delete.
+        matches!(
+            err.kind(),
+            io::ErrorKind::CrossesDevices | io::ErrorKind::Other
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::join_paths;

--- a/src/compiler/build_runner/compilation_files.rs
+++ b/src/compiler/build_runner/compilation_files.rs
@@ -126,6 +126,10 @@ pub struct CompilationFiles<'a, 'gctx> {
     pub(super) host: Layout,
     /// The target directory layout for the target (if different from then host).
     pub(super) target: HashMap<CompileTarget, Layout>,
+    /// Whether the cross-workspace build cache is usable (writable) for this
+    /// build. When disabled, cacheable units are treated as ordinary units and
+    /// built in the workspace.
+    cache_enabled: bool,
     /// Additional directory to include a copy of the outputs.
     export_dir: Option<PathBuf>,
     /// The root targets requested by the user on the command line (does not
@@ -177,10 +181,12 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
             .cloned()
             .map(|unit| (unit, OnceCell::new()))
             .collect();
+        let cache_enabled = host.cache_enabled();
         CompilationFiles {
             ws: build_runner.bcx.ws,
             host,
             target,
+            cache_enabled,
             export_dir: build_runner.bcx.build_config.export_dir.clone(),
             roots: build_runner.bcx.roots.clone(),
             metas,
@@ -276,14 +282,33 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
     /// Returns the host `deps` directory path for a given build unit.
     pub fn host_deps(&self, unit: &Unit) -> PathBuf {
         let dir = self.pkg_dir(unit);
-        self.host.build_dir().deps(&dir)
+        if self.is_cacheable(unit) {
+            self.host.build_cache().out(&dir)
+        } else {
+            self.host.build_dir().deps(&dir)
+        }
+    }
+
+    /// Returns whether the given unit should be built into the cross-workspace
+    /// build cache, i.e. it is eligible, the cache is usable, and the new
+    /// build-dir layout is in effect (the cache design assumes
+    /// `-Zbuild-dir-new-layout`, which is always on except when opted out via
+    /// `__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT`).
+    pub fn is_cacheable(&self, unit: &Unit) -> bool {
+        self.ws.gctx().cli_unstable().build_dir_new_layout
+            && self.cache_enabled
+            && unit.is_cacheable()
     }
 
     /// Returns the directories where Rust crate dependencies are found for the
     /// specified unit.
     pub fn deps_dir(&self, unit: &Unit) -> PathBuf {
         let dir = self.pkg_dir(unit);
-        self.layout(unit.kind).build_dir().deps(&dir)
+        if self.is_cacheable(unit) {
+            self.layout(unit.kind).build_cache().out(&dir)
+        } else {
+            self.layout(unit.kind).build_dir().deps(&dir)
+        }
     }
 
     /// Returns the directories where Rust crate dependencies are found for the
@@ -300,21 +325,69 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
     /// Directory where the fingerprint for the given unit should go.
     pub fn fingerprint_dir(&self, unit: &Unit) -> PathBuf {
         let dir = self.pkg_dir(unit);
-        self.layout(unit.kind).build_dir().fingerprint(&dir)
+        if self.is_cacheable(unit) {
+            self.layout(unit.kind).build_cache().fingerprint(&dir)
+        } else {
+            self.layout(unit.kind).build_dir().fingerprint(&dir)
+        }
     }
 
     /// The lock location for a given build unit.
     pub fn build_unit_lock(&self, unit: &Unit) -> PathBuf {
         let dir = self.pkg_dir(unit);
+        let unit_dir = if self.is_cacheable(unit) {
+            self.layout(unit.kind).build_cache().build_unit(&dir)
+        } else {
+            self.layout(unit.kind).build_dir().build_unit(&dir)
+        };
+        unit_dir.join(".lock")
+    }
+
+    /// The lock file guarding rmeta availability for a cacheable build unit.
+    ///
+    /// This lock is held exclusively while the unit is being compiled and the
+    /// `.rmeta` has not been produced yet. Once rustc reports the `.rmeta`
+    /// artifact the compiling Cargo downgrades it to shared, allowing other
+    /// Cargo processes to start pipelined compilation against the metadata
+    /// before the `.rlib` (or other final artifact) has been produced.
+    ///
+    /// Only meaningful for cacheable units; see [`Unit::is_cacheable`].
+    pub fn cache_rmeta_lock(&self, unit: &Unit) -> PathBuf {
+        let dir = self.pkg_dir(unit);
         self.layout(unit.kind)
-            .build_dir()
+            .build_cache()
             .build_unit(&dir)
-            .join(".lock")
+            .join(".rmeta.lock")
+    }
+
+    /// The lock file guarding full completion of a cacheable build unit.
+    ///
+    /// This lock is held exclusively while the unit is being compiled and
+    /// released (downgraded to shared) only after all artifacts have been
+    /// written *and* the fingerprint file has been persisted. Acquiring this
+    /// lock in shared mode therefore guarantees that the fingerprint file
+    /// exists and the unit can be used without recompiling it.
+    ///
+    /// Only meaningful for cacheable units; see [`Unit::is_cacheable`].
+    pub fn cache_rlib_lock(&self, unit: &Unit) -> PathBuf {
+        let dir = self.pkg_dir(unit);
+        self.layout(unit.kind)
+            .build_cache()
+            .build_unit(&dir)
+            .join(".rlib.lock")
     }
 
     /// Directory where incremental output for the given unit should go.
-    pub fn incremental_dir(&self, unit: &Unit) -> &Path {
-        self.layout(unit.kind).build_dir().incremental()
+    pub fn incremental_dir(&self, unit: &Unit) -> PathBuf {
+        let dir = self.pkg_dir(unit);
+        if self.is_cacheable(unit) {
+            self.layout(unit.kind).build_cache().incremental(&dir)
+        } else {
+            self.layout(unit.kind)
+                .build_dir()
+                .incremental()
+                .to_path_buf()
+        }
     }
 
     /// Directory where timing output should go.
@@ -767,6 +840,17 @@ fn compute_metadata(
         .package_id()
         .stable_hash(ws_root)
         .hash(&mut shared_hasher);
+
+    // The git revision is deliberately excluded from `stable_hash` (keeping
+    // cache folder names stable across revisions), but for the build cache it
+    // is part of the unit's identity: different revisions of the same git
+    // dependency produce different artifacts and must map to different cache
+    // entries. Otherwise two Cargo processes building different revisions of
+    // the same git URL concurrently would race on a shared cache directory
+    // (see `concurrent::git_same_branch_different_revs`).
+    if let Some(precise) = unit.pkg.package_id().source_id().precise_git_fragment() {
+        precise.hash(&mut shared_hasher);
+    }
 
     // Also mix in enabled features to our metadata. This'll ensure that
     // when changing feature sets each lib is separately cached.

--- a/src/compiler/build_runner/compilation_files.rs
+++ b/src/compiler/build_runner/compilation_files.rs
@@ -42,6 +42,13 @@ impl fmt::Debug for UnitHash {
     }
 }
 
+impl UnitHash {
+    /// Returns the raw hash value.
+    pub fn hash(&self) -> u64 {
+        self.0
+    }
+}
+
 /// [`Metadata`] tracks several [`UnitHash`]s, including
 /// [`Metadata::unit_id`], [`Metadata::c_metadata`], and [`Metadata::c_extra_filename`].
 ///

--- a/src/compiler/build_runner/mod.rs
+++ b/src/compiler/build_runner/mod.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::compiler::compilation::{self, UnitOutput};
 use crate::compiler::locking::LockManager;
-use crate::compiler::{self, Unit, UserIntent, artifact};
+use crate::compiler::{self, Unit, UnitIndex, UserIntent, artifact};
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::CargoResult;
 use crate::workspace::PackageId;
@@ -94,6 +94,11 @@ pub struct BuildRunner<'a, 'gctx> {
 
     /// Manages locks for build units when fine grain locking is enabled.
     pub lock_manager: Arc<LockManager>,
+
+    /// Indices of units built into the cross-workspace build cache; the
+    /// freshness mtime chain must ignore these dependencies (see
+    /// `Fingerprint::check_filesystem`).
+    pub cacheable_unit_indices: HashSet<UnitIndex>,
 }
 
 impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
@@ -135,6 +140,7 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
             failed_scrape_units: Arc::new(Mutex::new(HashSet::default())),
             unused_dep_state: UnusedDepState::new(bcx),
             lock_manager: Arc::new(LockManager::new()),
+            cacheable_unit_indices: HashSet::default(),
         })
     }
 
@@ -456,6 +462,19 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
         self.record_units_requiring_metadata();
 
         let files = CompilationFiles::new(self, host_layout, targets);
+        // Indices of units built into the cross-workspace build cache. The
+        // freshness mtime chain must ignore these dependencies: their cache
+        // artifacts are immutable, and their (normalized) fingerprint content
+        // is authoritative, so a newer mtime only means the shared cache entry
+        // was written after this unit last built — not that the dependency
+        // changed (see `Fingerprint::check_filesystem`).
+        self.cacheable_unit_indices = self
+            .bcx
+            .unit_to_index
+            .iter()
+            .filter(|(unit, _)| files.is_cacheable(unit))
+            .map(|(_, &index)| index)
+            .collect();
         self.files = Some(files);
         Ok(())
     }

--- a/src/compiler/cache.rs
+++ b/src/compiler/cache.rs
@@ -1,0 +1,285 @@
+//! Coordination for the cross-workspace build cache.
+//!
+//! Cacheable build units (see [`Unit::is_cacheable`]) are compiled directly
+//! inside `$CARGO_HOME/build-cache` and are immutable once complete. Because
+//! multiple Cargo processes may build and read the same unit concurrently,
+//! each cacheable unit directory carries two state lock files:
+//!
+//! * `.rmeta.lock` — held **exclusively** while the unit is being compiled and
+//!   its `.rmeta` has not yet been produced; downgraded to **shared** as soon
+//!   as rustc reports the `.rmeta` artifact (which rustc writes completely
+//!   before emitting the artifact notification). Other processes acquiring it
+//!   shared therefore know the `.rmeta` is safe to read, even though the
+//!   `.rlib` (or other final artifacts) are still being produced.
+//! * `.rlib.lock` — held **exclusively** while the unit is being compiled and
+//!   downgraded to **shared** only after all artifacts have been written *and*
+//!   the fingerprint file has been persisted. Acquiring it shared therefore
+//!   guarantees the fingerprint file exists, which is the cache's definition of
+//!   "complete".
+//!
+//! Locks are always acquired in the same order (`.rmeta.lock` before
+//! `.rlib.lock`) and contenders release their shared locks before attempting
+//! an exclusive upgrade, which keeps the multi-lock protocol free of
+//! lock-order cycles.
+//!
+//! ## Roles
+//!
+//! A job for a cacheable unit that was dirty at fingerprint-check time runs
+//! [`CacheCoordination::coordinate`] before compiling. It either becomes the
+//! **builder** (it compiles the unit) or a **waiter** (it observes the
+//! builder's progress):
+//!
+//! * **Builder**: holds both locks exclusively (after a fingerprint
+//!   double-check, since another process may have completed the unit while it
+//!   waited), compiles, downgrades `.rmeta.lock` to shared as soon as rustc
+//!   reports the `.rmeta` artifact so other processes can start pipelined
+//!   compilation against the metadata, and finally downgrades `.rlib.lock` to
+//!   shared after the fingerprint is written.
+//! * **Waiter**: takes `.rmeta.lock` shared (blocking until the rmeta is ready
+//!   or the builder is gone). If the unit is complete it is done. If the
+//!   builder is still compiling, it signals `rmeta_produced` early so its own
+//!   dependents can start type-checking against the metadata while the builder
+//!   still codegens, then blocks on `.rlib.lock` shared. If the builder crashed
+//!   (the fingerprint never appeared), it transitions to the builder role.
+//!
+//! ## Crash recovery
+//!
+//! If a builder dies mid-compile it releases its locks, leaving a partial unit
+//! with no fingerprint. The next process to run the protocol observes the
+//! missing fingerprint and takes over the build. All shared locks acquired
+//! while waiting are released before taking the exclusive locks, and the
+//! fingerprint is double-checked after acquisition, so concurrent contenders
+//! resolve to a single builder without deadlock.
+//!
+//! ## Known limitation
+//!
+//! If a builder crashes *after* producing the `.rmeta` but before completing
+//! the unit, a waiter may already have signaled `rmeta_produced` and started
+//! its dependents compiling against that `.rmeta`. When the waiter then takes
+//! over the build, its rustc invocation rewrites the `.rmeta` file while those
+//! dependents may still be reading it, which can in theory cause a torn read.
+//! The rewrite is byte-identical in practice (same unit, same inputs, same
+//! rustc), and the window requires a builder crash at a precise moment, so
+//! this is accepted for the PoC.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use crate::compiler::job_queue::{JobState, Work};
+use crate::compiler::locking::LockKey;
+use crate::compiler::{BuildRunner, Unit};
+use crate::util::{CargoResult, internal};
+
+/// Per-job coordination state for building one cacheable unit.
+pub struct CacheCoordination {
+    rmeta_path: PathBuf,
+    rlib_path: PathBuf,
+    fingerprint: PathBuf,
+    /// Hex fingerprint hash this unit would persist. A cached unit is
+    /// "complete for this identity" when the stored fingerprint file matches
+    /// this value (the content encodes identity information such as the git
+    /// revision that the unit hash does not capture).
+    expected_hash: String,
+    /// Whether the fingerprint's filesystem-status was up-to-date when it was
+    /// computed (see [`crate::compiler::fingerprint::CacheCompletionState`]).
+    /// A cache hit additionally requires this, so that changes to
+    /// non-cacheable dependencies (path patches) invalidate the unit.
+    fs_up_to_date: bool,    /// Lock keys, populated by [`CacheCoordination::coordinate`].
+    rmeta_key: OnceLock<LockKey>,
+    rlib_key: OnceLock<LockKey>,
+    /// Whether this process is (or became) the builder of the unit.
+    builder: AtomicBool,
+    /// Whether the rmeta lock has already been downgraded to shared.
+    rmeta_shared: AtomicBool,
+}
+
+impl CacheCoordination {
+    /// Creates the coordination state for a cacheable `unit`.
+    pub fn new(
+        build_runner: &mut BuildRunner<'_, '_>,
+        unit: &Unit,
+        completion: crate::compiler::fingerprint::CacheCompletionState,
+    ) -> CargoResult<Arc<Self>> {
+        Ok(Arc::new(CacheCoordination {
+            rmeta_path: build_runner.files().cache_rmeta_lock(unit),
+            rlib_path: build_runner.files().cache_rlib_lock(unit),
+            fingerprint: build_runner.files().fingerprint_file_path(unit, ""),
+            expected_hash: completion.hash,
+            fs_up_to_date: completion.fs_up_to_date,
+            rmeta_key: OnceLock::new(),
+            rlib_key: OnceLock::new(),
+            builder: AtomicBool::new(false),
+            rmeta_shared: AtomicBool::new(false),
+        }))
+    }
+
+    /// Returns whether the cached unit is complete for this unit's identity
+    /// and filesystem state.
+    ///
+    /// `builder_active` says whether another process was observed holding the
+    /// unit's locks (i.e. actively compiling) before this check. A builder
+    /// resolves the unit's dirtiness, so a content match alone is enough to
+    /// skip when one was seen. Without an active builder, the unit is only
+    /// complete when the fingerprint matches *and* the filesystem status was
+    /// up-to-date at prepare time — otherwise the staleness (e.g. a changed
+    /// path patch, or our own outputs missing on a cold cache) still needs to
+    /// be resolved by building.
+    fn is_complete(&self, builder_active: bool) -> bool {
+        let content_matches = match cargo_util::paths::read(&self.fingerprint) {
+            Ok(stored) => stored == self.expected_hash,
+            Err(_) => false,
+        };
+        content_matches && (self.fs_up_to_date || builder_active)
+    }
+
+    /// Returns whether any fingerprint file exists at all.
+    ///
+    /// A missing fingerprint means the unit was never built (cold cache). A
+    /// *present but mismatched* fingerprint means the unit is being rebuilt in
+    /// place with different identity content (e.g. a new git revision), in
+    /// which case pipelining against the stale rmeta would be incorrect.
+    fn fingerprint_exists(&self) -> bool {
+        self.fingerprint.exists()
+    }
+
+    /// Runs the coordination protocol for a cacheable unit.
+    ///
+    /// Returns `Ok(true)` if this process should compile the unit (builder
+    /// role). Returns `Ok(false)` if the unit is already complete (or was
+    /// completed while we waited), in which case the caller must skip the
+    /// compilation.
+    pub(crate) fn coordinate(&self, state: &JobState<'_, '_>) -> CargoResult<bool> {
+        loop {
+            // Wait until the `.rmeta` is (or was) available: the builder
+            // downgraded its rmeta lock to shared after rustc produced the
+            // file, the unit is complete, or the builder crashed and released
+            // its locks.
+            let rmeta = state.lock_shared_path(self.rmeta_path.clone())?;
+            let _ = self.rmeta_key.set(rmeta.clone());
+
+            // A fingerprint matching our expected hash, with an up-to-date
+            // filesystem status, means the unit is complete and immutable;
+            // there is nothing for us to do.
+            if self.is_complete(false) {
+                state.unlock(&rmeta)?;
+                return Ok(false);
+            }
+
+            // Try the rlib lock without blocking to detect whether a builder
+            // is still actively compiling.
+            let rlib = match state.try_lock_shared_path(self.rlib_path.clone())? {
+                // No builder is currently compiling the unit. The unit was
+                // either never built, already complete (completed while we
+                // waited for the rmeta lock), or a previous builder crashed;
+                // the first and last cases are handled by taking over below.
+                Some(rlib) => {
+                    // No builder observed; the unit is only complete if the
+                    // fingerprint matches and the filesystem status was
+                    // up-to-date at prepare time.
+                    if self.is_complete(false) {
+                        state.unlock(&rmeta)?;
+                        state.unlock(&rlib)?;
+                        return Ok(false);
+                    }
+                    rlib
+                }
+                // A builder is actively compiling. If the unit was never built
+                // (no fingerprint at all), our rmeta lock acquisition above
+                // proves its `.rmeta` is ready, so signal our own dependents
+                // to start pipelined compilation against the metadata while
+                // the builder still codegens. If the unit is being *rebuilt*
+                // in place (a stale fingerprint still exists), pipelining
+                // against the about-to-be-replaced rmeta would be incorrect,
+                // so we simply wait for completion.
+                None => {
+                    if !self.fingerprint_exists() {
+                        state.rmeta_produced();
+                    }
+                    // Wait for the builder to finish (or crash and release).
+                    // A builder was observed, so a matching fingerprint is
+                    // sufficient: it resolved the dirtiness.
+                    let rlib = state.lock_shared_path(self.rlib_path.clone())?;
+                    let _ = self.rlib_key.set(rlib.clone());
+                    if self.is_complete(true) {
+                        state.unlock(&rmeta)?;
+                        state.unlock(&rlib)?;
+                        return Ok(false);
+                    }
+                    // The builder crashed after producing the rmeta; we must
+                    // complete the unit ourselves.
+                    rlib
+                }
+            };
+            let _ = self.rlib_key.set(rlib.clone());
+
+            // Take the locks exclusively. Release our shared locks first so we
+            // hold nothing while acquiring, then probe the rmeta lock: if
+            // another process holds it (a builder that just finished, or
+            // another waiter), it will resolve the unit's state — waiting for
+            // it on the shared rlib lock (again holding nothing) is bounded by
+            // that process's job and cannot deadlock, even when that process
+            // is itself waiting on a unit whose locks we hold.
+            state.unlock(&rlib)?;
+            state.unlock(&rmeta)?;
+            let contended = !state.try_lock_exclusive(&rmeta)?;
+            if contended {
+                // Someone else holds this unit's locks. They are either
+                // building it or waiting on it; either way their job will
+                // resolve the state. Wait for that job, then re-evaluate from
+                // scratch rather than blocking on the exclusive lock.
+                let rlib = state.lock_shared_path(self.rlib_path.clone())?;
+                let _ = self.rlib_key.set(rlib.clone());
+                if self.is_complete(true) {
+                    state.unlock(&rlib)?;
+                    return Ok(false);
+                }
+                state.unlock(&rlib)?;
+                continue;
+            }
+            state.lock_exclusive(&rmeta)?;
+            state.lock_exclusive(&rlib)?;
+            if self.is_complete(false) {
+                state.unlock(&rlib)?;
+                state.unlock(&rmeta)?;
+                return Ok(false);
+            }
+            self.builder.store(true, Ordering::SeqCst);
+            return Ok(true);
+        }
+    }
+
+    /// Downgrades the rmeta lock to shared. Called when rustc reports the
+    /// `.rmeta` artifact (builder path) and again after the fingerprint is
+    /// written (in case rustc never reported an rmeta, e.g. for units whose
+    /// dependents do not pipeline). Idempotent.
+    pub(crate) fn downgrade_rmeta(&self, state: &JobState<'_, '_>) -> CargoResult<()> {
+        if !self.rmeta_shared.swap(true, Ordering::SeqCst) {
+            let key = self
+                .rmeta_key
+                .get()
+                .ok_or_else(|| internal("cache rmeta lock was not acquired"))?;
+            state.downgrade_to_shared(key)?;
+        }
+        Ok(())
+    }
+
+    /// Work to run after the unit's fingerprint has been written.
+    ///
+    /// Downgrades the rlib lock to shared, completing the unit from the
+    /// perspective of other processes. No-op for waiters.
+    pub fn after_work(this: &Arc<Self>) -> Work {
+        let this = Arc::clone(this);
+        Work::new(move |state| {
+            if this.builder.load(Ordering::SeqCst) {
+                this.downgrade_rmeta(state)?;
+                let key = this
+                    .rlib_key
+                    .get()
+                    .ok_or_else(|| internal("cache rlib lock was not acquired"))?;
+                state.downgrade_to_shared(key)?;
+            }
+            Ok(())
+        })
+    }
+}

--- a/src/compiler/fingerprint/dep_info.rs
+++ b/src/compiler/fingerprint/dep_info.rs
@@ -378,6 +378,7 @@ pub fn translate_dep_info(
             checksum_info.map(|(len, checksum)| (len, checksum.to_string())),
         ));
     }
+    println!("DI2={cargo_dep_info:?}");
     paths::write(cargo_dep_info, on_disk_info.serialize()?)?;
     Ok(())
 }
@@ -476,6 +477,7 @@ pub fn parse_dep_info(
     build_root: &Path,
     dep_info: &Path,
 ) -> CargoResult<Option<RustcDepInfo>> {
+    println!("DI={dep_info:?}");
     let Ok(data) = paths::read_bytes(dep_info) else {
         return Ok(None);
     };

--- a/src/compiler/fingerprint/dep_info.rs
+++ b/src/compiler/fingerprint/dep_info.rs
@@ -378,7 +378,6 @@ pub fn translate_dep_info(
             checksum_info.map(|(len, checksum)| (len, checksum.to_string())),
         ));
     }
-    println!("DI2={cargo_dep_info:?}");
     paths::write(cargo_dep_info, on_disk_info.serialize()?)?;
     Ok(())
 }
@@ -477,7 +476,6 @@ pub fn parse_dep_info(
     build_root: &Path,
     dep_info: &Path,
 ) -> CargoResult<Option<RustcDepInfo>> {
-    println!("DI={dep_info:?}");
     let Ok(data) = paths::read_bytes(dep_info) else {
         return Ok(None);
     };

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -466,12 +466,20 @@ pub fn prepare_target(
 
     debug!("fingerprint at: {}", loc.display());
 
-    if unit.is_cacheable() {
-        if loc.exists() {
-            // Build cache units are immutable so if it exists, its fresh.
-            return Ok(Job::new_fresh());
-        }
-    }
+    // Cacheable units use the normal fingerprint comparison (hash match plus
+    // filesystem status). The hash match catches identity changes that are not
+    // part of the unit hash (e.g. a git revision, which appears in the
+    // checkout directory path and surfaces as `PathToSourceChanged`); the
+    // filesystem-status check catches changes to *non-cacheable*
+    // dependencies, most notably path patches of registry crates, whose
+    // mtimes are not reflected in any hash. The artifacts stay effectively
+    // immutable: nothing rebuilds them unless one of these conditions fires.
+    //
+    // Note that the fingerprint *content* (and thus a fresh cache hit) is
+    // stable across byte-identical rebuilds of the same unit by another
+    // workspace, but such a rebuild updates the artifact mtimes, which the
+    // filesystem-status check propagates as a (correct, conservative)
+    // relink/rebuild of dependents.
 
     // Figure out if this unit is up to date. After calculating the fingerprint
     // compare it to an old version, if any, and attempt to print diagnostic
@@ -1584,15 +1592,19 @@ fn calculate_normal(
         // built. The only exception here are artifact dependencies,
         // which is an actual dependency that needs a recompile.
         //
+        // Note: cacheable dependencies ARE included here. Even though their own
+        // freshness is determined by fingerprint-file existence in the build
+        // cache (they are immutable), their dependents still need to know when
+        // the dependency *identity* changes (e.g. a git dependency moving to a
+        // new revision, which produces a new build unit). That change must
+        // propagate as dirtiness to non-cacheable dependents such as binaries
+        // and build scripts.
+        //
         // Create Vec since mutable build_runner is needed in closure.
         let deps = Vec::from(build_runner.unit_deps(unit));
         let mut deps = deps
             .into_iter()
             .filter(|dep| {
-                if dep.unit.is_cacheable() {
-                    return false;
-                }
-
                 !dep.unit.target.is_bin() || dep.unit.artifact.is_true()
             })
             .map(|dep| DepFingerprint::new(build_runner, unit, &dep))
@@ -1616,7 +1628,21 @@ fn calculate_normal(
         vec![LocalFingerprint::Precalculated(fingerprint)]
     } else {
         let dep_info = dep_info_loc(build_runner, unit);
-        let dep_info = dep_info.strip_prefix(&build_root).unwrap().to_path_buf();
+        let dep_info = if build_runner.files().is_cacheable(unit) {
+            // The dep-info for a cacheable unit lives in the build cache, not
+            // under the workspace build root, so it cannot be encoded relative
+            // to it. Store the absolute path: `find_stale_item` joins it with
+            // the build root, which is a no-op for absolute paths. This is
+            // acceptable because the fingerprint itself lives in the build
+            // cache and is therefore not portable between machines anyway.
+            // Keeping `CheckDepInfo` (rather than a precalculated value)
+            // preserves the dep-info's environment-variable tracking (used by
+            // `-Zrustdoc-depinfo` and `-Zbinary-dep-depinfo`) and any source
+            // mtime checking.
+            dep_info
+        } else {
+            dep_info.strip_prefix(&build_root).unwrap().to_path_buf()
+        };
         vec![LocalFingerprint::CheckDepInfo {
             dep_info,
             checksum: build_runner.bcx.gctx.cli_unstable().checksum_freshness,
@@ -1767,6 +1793,8 @@ See https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-change
         // Create Vec since mutable build_runner is needed in closure.
         let deps = Vec::from(build_runner.unit_deps(unit));
         deps.into_iter()
+            // Cacheable dependencies are included so that a dependency identity
+            // change (e.g. a new git revision) re-runs the build script.
             .map(|dep| DepFingerprint::new(build_runner, unit, &dep))
             .collect::<CargoResult<Vec<_>>>()?
     };
@@ -1994,11 +2022,39 @@ pub fn prepare_init(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> Carg
     let new1 = build_runner.files().fingerprint_dir(unit);
 
     // Doc tests have no output, thus no fingerprint.
-    if !new1.exists() && !unit.mode.is_doc_test() && !unit.is_cacheable() {
+    if !new1.exists() && !unit.mode.is_doc_test() {
         paths::create_dir_all(&new1)?;
     }
 
     Ok(())
+}
+
+/// The state needed by the build cache's coordination protocol to decide
+/// whether a cached unit is complete *for this unit's identity and filesystem
+/// state*.
+pub(crate) struct CacheCompletionState {
+    /// Hex fingerprint hash this unit would persist. The stored fingerprint
+    /// file encodes identity information (e.g. the git revision) beyond what
+    /// the unit hash captures, so completion is checked by comparing file
+    /// content rather than mere existence.
+    pub(crate) hash: String,
+    /// Whether the fingerprint's filesystem-status was up-to-date when it was
+    /// computed. This catches changes to *non-cacheable* dependencies (such
+    /// as path patches of registry crates) whose mtimes are not reflected in
+    /// any hash.
+    pub(crate) fs_up_to_date: bool,
+}
+
+/// Returns the fingerprint state a cacheable `unit` would persist.
+pub(crate) fn cache_completion_state(
+    build_runner: &mut BuildRunner<'_, '_>,
+    unit: &Unit,
+) -> CargoResult<CacheCompletionState> {
+    let fingerprint = calculate(build_runner, unit)?;
+    Ok(CacheCompletionState {
+        hash: util::to_hex(fingerprint.hash_u64()),
+        fs_up_to_date: fingerprint.fs_status.up_to_date(),
+    })
 }
 
 /// Returns the location that the dep-info file will show up at

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -380,7 +380,7 @@ mod dep_info;
 mod dirty_reason;
 mod rustdoc;
 
-use crate::util::data_structures::HashMap;
+use crate::util::data_structures::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
 use std::env;
 use std::ffi::OsString;
@@ -486,8 +486,14 @@ pub fn prepare_target(
     // information about failed comparisons to aid in debugging.
     let fingerprint = calculate(build_runner, unit)?;
     let mtime_on_use = build_runner.bcx.gctx.cli_unstable().mtime_on_use;
-    let dirty_reason = match compare_old_fingerprint(unit, &loc, &*fingerprint, mtime_on_use, force)
-    {
+    let dirty_reason = match compare_old_fingerprint(
+        unit,
+        &loc,
+        &*fingerprint,
+        mtime_on_use,
+        force,
+        build_runner.files().is_cacheable(unit),
+    ) {
         FingerprintComparison::Fresh => None,
         FingerprintComparison::Dirty { reason } => Some(reason),
     };
@@ -743,6 +749,25 @@ impl FsStatus {
             | FsStatus::StaleDepFingerprint { .. } => false,
         }
     }
+
+    /// Whether the filesystem state is compatible with a build-cache hit.
+    ///
+    /// For cacheable units the fingerprint *content* is the authoritative
+    /// signal: the normalized dependency hashes change exactly when a
+    /// dependency's identity or (for path dependencies) its source content
+    /// changes. Dependency staleness (`StaleDependency`/`StaleDepFingerprint`)
+    /// merely means a dependency was rebuilt, which a byte-identical rebuild
+    /// (e.g. after `cargo clean` of the workspace target dir) does not
+    /// invalidate. `Stale` and `StaleItem` still require a rebuild: they mean
+    /// the unit's own outputs are missing or its own inputs changed.
+    fn cache_compatible(&self) -> bool {
+        matches!(
+            self,
+            FsStatus::UpToDate { .. }
+                | FsStatus::StaleDependency { .. }
+                | FsStatus::StaleDepFingerprint { .. }
+        )
+    }
 }
 
 mod serde_file_time {
@@ -826,7 +851,7 @@ impl<'de> Deserialize<'de> for DepFingerprint {
 /// when the filesystem contains stale information (based on mtime currently).
 /// The paths here don't change much between compilations but they're used as
 /// inputs when we probe the filesystem looking at information.
-#[derive(Debug, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash)]
 enum LocalFingerprint {
     /// This is a precalculated fingerprint which has an opaque string we just
     /// hash as usual. This variant is primarily used for rustdoc where we
@@ -1076,6 +1101,43 @@ impl Fingerprint {
         *self.memoized_hash.lock().unwrap() = None;
     }
 
+    /// Deep-clones this fingerprint (dependencies included).
+    ///
+    /// Unlike a `serde` round-trip this preserves the `index` field, which is
+    /// needed to map dependency fingerprints back to their [`Unit`]s when
+    /// normalizing them for the build cache. The memoized hash is cleared so
+    /// the clone's hash recomputes from its (possibly modified) content; the
+    /// filesystem status is copied as-is.
+    fn deep_clone(&self) -> Fingerprint {
+        Fingerprint {
+            rustc: self.rustc,
+            features: self.features.clone(),
+            declared_features: self.declared_features.clone(),
+            target: self.target,
+            path: self.path,
+            profile: self.profile,
+            deps: self
+                .deps
+                .iter()
+                .map(|dep| DepFingerprint {
+                    pkg_id: dep.pkg_id,
+                    name: dep.name,
+                    public: dep.public,
+                    only_requires_rmeta: dep.only_requires_rmeta,
+                    fingerprint: Arc::new(dep.fingerprint.deep_clone()),
+                })
+                .collect(),
+            local: Mutex::new(self.local.lock().unwrap().clone()),
+            memoized_hash: Mutex::new(None),
+            rustflags: self.rustflags.clone(),
+            config: self.config,
+            compile_kind: self.compile_kind,
+            index: self.index,
+            fs_status: self.fs_status.clone(),
+            outputs: self.outputs.clone(),
+        }
+    }
+
     fn hash_u64(&self) -> u64 {
         if let Some(s) = *self.memoized_hash.lock().unwrap() {
             return s;
@@ -1266,6 +1328,7 @@ impl Fingerprint {
         build_root: &Path,
         cargo_exe: &Path,
         gctx: &GlobalContext,
+        cacheable_indices: &HashSet<UnitIndex>,
     ) -> CargoResult<()> {
         assert!(!self.fs_status.up_to_date());
 
@@ -1302,64 +1365,86 @@ impl Fingerprint {
             pkg_root, max_path, max_mtime
         );
 
-        for dep in self.deps.iter() {
-            let dep_mtimes = match &dep.fingerprint.fs_status {
-                FsStatus::UpToDate { mtimes } => mtimes,
-                // If our dependency is stale, so are we, so bail out.
-                FsStatus::Stale
-                | FsStatus::StaleItem(_)
-                | FsStatus::StaleDependency { .. }
-                | FsStatus::StaleDepFingerprint { .. } => {
-                    self.fs_status = FsStatus::StaleDepFingerprint {
-                        unit: dep.fingerprint.index,
+        // Cacheable units live in the shared build cache, whose artifacts'
+        // mtimes only reflect when the cache entry was written — not when the
+        // unit's dependencies were last rebuilt in a workspace. A cache entry
+        // is almost always *older* than freshly-rebuilt non-cacheable
+        // dependencies, so the mtime chain against dependencies is meaningless
+        // for them; their (normalized) fingerprint content is the authoritative
+        // signal. Skipping the dependency loop also prevents a dependency's
+        // mtime-bumped stale fs-status from leaking into dependents, which
+        // would otherwise rebuild a cache hit forever (the cache artifacts'
+        // mtimes are never refreshed).
+        if !cacheable_indices.contains(&self.index) {
+            for dep in self.deps.iter() {
+                let dep_mtimes = match &dep.fingerprint.fs_status {
+                        FsStatus::UpToDate { mtimes } => mtimes,
+                        // If our dependency is stale, so are we, so bail out.
+                        FsStatus::Stale
+                        | FsStatus::StaleItem(_)
+                        | FsStatus::StaleDependency { .. }
+                        | FsStatus::StaleDepFingerprint { .. } => {
+                            self.fs_status = FsStatus::StaleDepFingerprint {
+                                unit: dep.fingerprint.index,
+                            };
+                            return Ok(());
+                        }
                     };
-                    return Ok(());
-                }
-            };
-
-            // If our dependency edge only requires the rmeta file to be present
-            // then we only need to look at that one output file, otherwise we
-            // need to consider all output files to see if we're out of date.
-            let (dep_path, dep_mtime) = if dep.only_requires_rmeta {
-                dep_mtimes
-                    .iter()
-                    .find(|(path, _mtime)| {
-                        path.extension().and_then(|s| s.to_str()) == Some("rmeta")
-                    })
-                    .expect("failed to find rmeta")
-            } else {
-                match dep_mtimes.iter().max_by_key(|kv| kv.1) {
-                    Some(dep_mtime) => dep_mtime,
-                    // If our dependencies is up to date and has no filesystem
-                    // interactions, then we can move on to the next dependency.
-                    None => continue,
-                }
-            };
-            debug!(
-                "max dep mtime for {:?} is {:?} {}",
-                pkg_root, dep_path, dep_mtime
-            );
-
-            // If the dependency is newer than our own output then it was
-            // recompiled previously. We transitively become stale ourselves in
-            // that case, so bail out.
-            //
-            // Note that this comparison should probably be `>=`, not `>`, but
-            // for a discussion of why it's `>` see the discussion about #5918
-            // below in `find_stale`.
-            if dep_mtime > max_mtime {
-                info!(
-                    "dependency on `{}` is newer than we are {} > {} {:?}",
-                    dep.name, dep_mtime, max_mtime, pkg_root
-                );
-
-                self.fs_status = FsStatus::StaleDependency {
-                    unit: dep.fingerprint.index,
-                    dep_mtime: *dep_mtime,
-                    max_mtime: *max_mtime,
+    
+                    // Dependencies built into the cross-workspace build cache are
+                    // immutable: their artifacts' mtimes only reflect when the
+                    // shared cache entry was written, not whether the dependency
+                    // changed. Their normalized fingerprint content (embedded in
+                    // this fingerprint) is the authoritative freshness signal, so
+                    // skip the mtime comparison for them.
+                    if cacheable_indices.contains(&dep.fingerprint.index) {
+                        continue;
+                    }
+    
+                // If our dependency edge only requires the rmeta file to be present
+                // then we only need to look at that one output file, otherwise we
+                // need to consider all output files to see if we're out of date.
+                let (dep_path, dep_mtime) = if dep.only_requires_rmeta {
+                    dep_mtimes
+                        .iter()
+                        .find(|(path, _mtime)| {
+                            path.extension().and_then(|s| s.to_str()) == Some("rmeta")
+                        })
+                        .expect("failed to find rmeta")
+                } else {
+                    match dep_mtimes.iter().max_by_key(|kv| kv.1) {
+                        Some(dep_mtime) => dep_mtime,
+                        // If our dependencies is up to date and has no filesystem
+                        // interactions, then we can move on to the next dependency.
+                        None => continue,
+                    }
                 };
-
-                return Ok(());
+                debug!(
+                    "max dep mtime for {:?} is {:?} {}",
+                    pkg_root, dep_path, dep_mtime
+                );
+    
+                // If the dependency is newer than our own output then it was
+                // recompiled previously. We transitively become stale ourselves in
+                // that case, so bail out.
+                //
+                // Note that this comparison should probably be `>=`, not `>`, but
+                // for a discussion of why it's `>` see the discussion about #5918
+                // below in `find_stale`.
+                if dep_mtime > max_mtime {
+                    info!(
+                        "dependency on `{}` is newer than we are {} > {} {:?}",
+                        dep.name, dep_mtime, max_mtime, pkg_root
+                    );
+    
+                    self.fs_status = FsStatus::StaleDependency {
+                        unit: dep.fingerprint.index,
+                        dep_mtime: *dep_mtime,
+                        max_mtime: *max_mtime,
+                    };
+    
+                    return Ok(());
+            }
             }
         }
 
@@ -1532,6 +1617,69 @@ impl StaleItem {
     }
 }
 
+/// Normalizes a cacheable unit's fingerprint tree for stable cache entries.
+///
+/// A `run-custom-build` unit's `local` fingerprint switches between the
+/// whole-crate `Precalculated` form (when the previous run's output is
+/// missing) and the `RerunIfChanged`/`RerunIfEnvChanged` form (when it is
+/// present). Which form applies depends on environmental state (was the
+/// workspace build dir cleaned since the build script last ran), so a
+/// fingerprint that embeds it differs between builds of identical inputs —
+/// invalidating otherwise-immutable cache entries after a `cargo clean`.
+///
+/// For cacheable units the dependency fingerprint is replaced by the
+/// deterministic, content-based `Precalculated(pkg_fingerprint)` form
+/// (recursively):
+///
+/// * For `run-custom-build` dependencies the build script's inputs are its
+///   package (captured by `pkg_fingerprint`) — the `rerun-if-*` bookkeeping
+///   adds no information for immutable registry/git sources.
+/// * For local (path) dependencies the package fingerprint is mtime-based, so
+///   source edits still invalidate the cache entry — this is what catches
+///   path patches of registry crates, which the normal dependency hash (a
+///   stable path) would miss.
+///
+/// The clone is private to the cacheable unit's fingerprint, so the shared
+/// fingerprints used for the dependencies' own freshness checks are
+/// untouched.
+fn normalize_cache_fingerprint(
+    build_runner: &BuildRunner<'_, '_>,
+    fingerprint: &Fingerprint,
+) -> CargoResult<Fingerprint> {
+    let clone = fingerprint.deep_clone();
+    let index_to_unit: HashMap<UnitIndex, Unit> = build_runner
+        .bcx
+        .unit_to_index
+        .iter()
+        .map(|(unit, &index)| (index, unit.clone()))
+        .collect();
+    normalize_cache_deps(build_runner, &clone, &index_to_unit)?;
+    Ok(clone)
+}
+
+/// Recursively replaces the `local` fingerprints of `run-custom-build` and
+/// local dependencies of `fp` with their content-based package fingerprint.
+fn normalize_cache_deps(
+    build_runner: &BuildRunner<'_, '_>,
+    fp: &Fingerprint,
+    index_to_unit: &HashMap<UnitIndex, Unit>,
+) -> CargoResult<()> {
+    for dep in &fp.deps {
+        let unit = index_to_unit
+            .get(&dep.fingerprint.index)
+            .ok_or_else(|| internal("missing unit for fingerprint index"))?;
+        if unit.mode.is_run_custom_build() || unit.is_local() {
+            let s = pkg_fingerprint(build_runner.bcx, &unit.pkg)?;
+            // `local` is interior-mutable; the fingerprint itself (and the
+            // shared dependency fingerprints) must not be mutated, since the
+            // dependencies' own freshness checks use them.
+            *dep.fingerprint.local.lock().unwrap() = vec![LocalFingerprint::Precalculated(s)];
+        }
+        normalize_cache_deps(build_runner, &dep.fingerprint, index_to_unit)?;
+    }
+    Ok(())
+}
+
 /// Calculates the fingerprint for a [`Unit`].
 ///
 /// This fingerprint is used by Cargo to learn about when information such as:
@@ -1569,9 +1717,19 @@ fn calculate(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         &build_root,
         cargo_exe,
         build_runner.bcx.gctx,
+        &build_runner.cacheable_unit_indices,
     )?;
 
-    let fingerprint = Arc::new(fingerprint);
+    let fingerprint = if build_runner.files().is_cacheable(unit) {
+        // Cacheable units must have stable fingerprints across workspace
+        // cleans: see `normalize_cache_fingerprint`. The normalized clone is
+        // what gets persisted and what dependents embed, so a cache entry
+        // built once matches every later freshness check of identical inputs.
+        let normalized = normalize_cache_fingerprint(build_runner, &fingerprint)?;
+        Arc::new(normalized)
+    } else {
+        Arc::new(fingerprint)
+    };
     build_runner
         .fingerprints
         .insert(unit.clone(), Arc::clone(&fingerprint));
@@ -2053,7 +2211,7 @@ pub(crate) fn cache_completion_state(
     let fingerprint = calculate(build_runner, unit)?;
     Ok(CacheCompletionState {
         hash: util::to_hex(fingerprint.hash_u64()),
-        fs_up_to_date: fingerprint.fs_status.up_to_date(),
+        fs_up_to_date: fingerprint.fs_status.cache_compatible(),
     })
 }
 
@@ -2079,6 +2237,7 @@ fn compare_old_fingerprint(
     new_fingerprint: &Fingerprint,
     mtime_on_use: bool,
     forced: bool,
+    cache_compatible: bool,
 ) -> FingerprintComparison {
     if mtime_on_use {
         // update the mtime so other cleaners know we used it
@@ -2087,7 +2246,7 @@ fn compare_old_fingerprint(
         paths::set_file_time_no_err(old_hash_path, t);
     }
 
-    let compare = _compare_old_fingerprint(old_hash_path, new_fingerprint);
+    let compare = _compare_old_fingerprint(old_hash_path, new_fingerprint, cache_compatible);
 
     match compare.as_ref() {
         Ok(FingerprintComparison::Fresh) => {}
@@ -2121,12 +2280,18 @@ fn compare_old_fingerprint(
 fn _compare_old_fingerprint(
     old_hash_path: &Path,
     new_fingerprint: &Fingerprint,
+    cache_compatible: bool,
 ) -> CargoResult<FingerprintComparison> {
     let old_fingerprint_short = paths::read(old_hash_path)?;
 
     let new_hash = new_fingerprint.hash_u64();
 
-    if util::to_hex(new_hash) == old_fingerprint_short && new_fingerprint.fs_status.up_to_date() {
+    let fs_ok = if cache_compatible {
+        new_fingerprint.fs_status.cache_compatible()
+    } else {
+        new_fingerprint.fs_status.up_to_date()
+    };
+    if util::to_hex(new_hash) == old_fingerprint_short && fs_ok {
         return Ok(FingerprintComparison::Fresh);
     }
 

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -485,6 +485,16 @@ pub fn prepare_target(
     // compare it to an old version, if any, and attempt to print diagnostic
     // information about failed comparisons to aid in debugging.
     let fingerprint = calculate(build_runner, unit)?;
+    let is_cacheable = build_runner.files().is_cacheable(unit);
+    // The rmeta paths of every dependency (transitively), used to refresh the
+    // pinned content checksums when the fingerprint is written after a build
+    // (the checksums are "missing" placeholders in a cold cache, since the
+    // dependencies are not built yet when the fingerprint is calculated).
+    let rmeta_checksum_paths = if is_cacheable {
+        collect_dep_rmeta_paths(build_runner, &fingerprint)?
+    } else {
+        Vec::new()
+    };
     let mtime_on_use = build_runner.bcx.gctx.cli_unstable().mtime_on_use;
     let dirty_reason = match compare_old_fingerprint(
         unit,
@@ -492,7 +502,7 @@ pub fn prepare_target(
         &*fingerprint,
         mtime_on_use,
         force,
-        build_runner.files().is_cacheable(unit),
+        is_cacheable,
     ) {
         FingerprintComparison::Fresh => None,
         FingerprintComparison::Dirty { reason } => Some(reason),
@@ -603,6 +613,18 @@ pub fn prepare_target(
 
             write_fingerprint(&loc, &fingerprint)
         })
+    } else if is_cacheable {
+        // The prepared fingerprint pins each dependency's rmeta content
+        // checksum (see `normalize_cache_deps`). For a cold cache the
+        // dependencies have not been built yet when the fingerprint is
+        // calculated, so their checksums are the "missing" placeholder;
+        // recompute them now that the dependencies exist so the persisted
+        // fingerprint reflects the artifacts the unit was actually compiled
+        // against.
+        Work::new(move |_| {
+            refresh_cache_dep_checksums(&fingerprint, &rmeta_checksum_paths)?;
+            write_fingerprint(&loc, &fingerprint)
+        })
     } else {
         Work::new(move |_| write_fingerprint(&loc, &fingerprint))
     };
@@ -659,6 +681,18 @@ struct DepFingerprint {
 pub struct Fingerprint {
     /// Hash of the version of `rustc` used.
     rustc: u64,
+    /// The unit's `-C metadata` value (its artifact identity).
+    ///
+    /// The fingerprint must capture the exact `-C metadata` the unit's
+    /// artifacts were compiled with: a dependency's artifacts embed each
+    /// other's metadata hashes, so if a dependency is (re)built with a
+    /// different metadata (e.g. a stale workspace artifact produced by an
+    /// older cargo binary, or a divergent unit graph), every cached artifact
+    /// that links it becomes unusable (`E0460`/`E0463`) even though the
+    /// source content is unchanged. Without this field the freshness check
+    /// would accept such an entry forever.
+    #[serde(default)]
+    metadata: u64,
     /// Sorted list of cfg features enabled.
     features: String,
     /// Sorted list of all the declared cfg features.
@@ -1074,6 +1108,7 @@ impl Fingerprint {
     fn new() -> Fingerprint {
         Fingerprint {
             rustc: 0,
+            metadata: 0,
             target: 0,
             profile: 0,
             path: 0,
@@ -1111,6 +1146,7 @@ impl Fingerprint {
     fn deep_clone(&self) -> Fingerprint {
         Fingerprint {
             rustc: self.rustc,
+            metadata: self.metadata,
             features: self.features.clone(),
             declared_features: self.declared_features.clone(),
             target: self.target,
@@ -1479,6 +1515,7 @@ impl hash::Hash for Fingerprint {
     fn hash<H: Hasher>(&self, h: &mut H) {
         let Fingerprint {
             rustc,
+            metadata,
             ref features,
             ref declared_features,
             target,
@@ -1494,6 +1531,7 @@ impl hash::Hash for Fingerprint {
         let local = local.lock().unwrap();
         (
             rustc,
+            metadata,
             features,
             declared_features,
             target,
@@ -1658,7 +1696,17 @@ fn normalize_cache_fingerprint(
 }
 
 /// Recursively replaces the `local` fingerprints of `run-custom-build` and
-/// local dependencies of `fp` with their content-based package fingerprint.
+/// local dependencies of `fp` with their content-based package fingerprint,
+/// mixed with the dependency's `-C metadata` and the checksum of its rmeta
+/// artifact.
+///
+/// The rmeta checksum matters because a dependency's rmeta embeds
+/// workspace-specific absolute paths (e.g. the `OUT_DIR` of a build-script
+/// dependency), so two artifacts for the *same* unit (same `-C metadata`)
+/// built in different workspaces are not interchangeable: rustc rejects the
+/// mismatch with `E0460`/`E0463` when a cached dependent links against them.
+/// Pinning the rmeta content makes the freshness check rebuild the cached
+/// entry whenever the dependency's artifact diverges.
 fn normalize_cache_deps(
     build_runner: &BuildRunner<'_, '_>,
     fp: &Fingerprint,
@@ -1668,14 +1716,123 @@ fn normalize_cache_deps(
         let unit = index_to_unit
             .get(&dep.fingerprint.index)
             .ok_or_else(|| internal("missing unit for fingerprint index"))?;
-        if unit.mode.is_run_custom_build() || unit.is_local() {
-            let s = pkg_fingerprint(build_runner.bcx, &unit.pkg)?;
-            // `local` is interior-mutable; the fingerprint itself (and the
-            // shared dependency fingerprints) must not be mutated, since the
-            // dependencies' own freshness checks use them.
-            *dep.fingerprint.local.lock().unwrap() = vec![LocalFingerprint::Precalculated(s)];
-        }
+        let s = pkg_fingerprint(build_runner.bcx, &unit.pkg)?;
+        let meta = build_runner.files().metadata(unit).c_metadata();
+        let rmeta_checksum = dep_rmeta_checksum(build_runner, unit)?;
+        // `local` is interior-mutable; the fingerprint itself (and the
+        // shared dependency fingerprints) must not be mutated, since the
+        // dependencies' own freshness checks use them.
+        *dep.fingerprint.local.lock().unwrap() =
+            vec![LocalFingerprint::Precalculated(format!("{s}:{meta}:{rmeta_checksum}"))];
         normalize_cache_deps(build_runner, &dep.fingerprint, index_to_unit)?;
+    }
+    Ok(())
+}
+
+/// Returns the content hash of the given unit's rmeta artifact, or a marker
+/// string when the unit produces no rmeta (e.g. an overridden build script) or
+/// the artifact is not built yet (a cold cache, where the dependency has not
+/// been compiled; the "missing" marker then differs from any real checksum, so
+/// the entry is rebuilt once the dependency's artifact exists).
+fn dep_rmeta_checksum(
+    build_runner: &BuildRunner<'_, '_>,
+    unit: &Unit,
+) -> CargoResult<String> {
+    let outputs = build_runner.outputs(unit)?;
+    if let Some(rmeta) = outputs.iter().find(|o| o.flavor == FileFlavor::Rmeta) {
+        let bytes = match std::fs::read(&rmeta.path) {
+            Ok(bytes) => bytes,
+            Err(_) => return Ok("missing".to_string()),
+        };
+        return Ok(format!("{:x}", util::hash_u64(&bytes)));
+    }
+    Ok("none".to_string())
+}
+
+/// Collects the rmeta artifact path of every (transitive) dependency of the
+/// given fingerprint, in the same order [`refresh_cache_dep_checksums`] walks
+/// them. Dependencies without an rmeta artifact get an empty sentinel path.
+fn collect_dep_rmeta_paths(
+    build_runner: &BuildRunner<'_, '_>,
+    fp: &Fingerprint,
+) -> CargoResult<Vec<PathBuf>> {
+    let index_to_unit: HashMap<UnitIndex, Unit> = build_runner
+        .bcx
+        .unit_to_index
+        .iter()
+        .map(|(unit, &index)| (index, unit.clone()))
+        .collect();
+    let mut paths = Vec::new();
+    collect_dep_rmeta_paths_inner(build_runner, fp, &index_to_unit, &mut paths)?;
+    Ok(paths)
+}
+
+fn collect_dep_rmeta_paths_inner(
+    build_runner: &BuildRunner<'_, '_>,
+    fp: &Fingerprint,
+    index_to_unit: &HashMap<UnitIndex, Unit>,
+    paths: &mut Vec<PathBuf>,
+) -> CargoResult<()> {
+    for dep in &fp.deps {
+        let unit = index_to_unit
+            .get(&dep.fingerprint.index)
+            .ok_or_else(|| internal("missing unit for fingerprint index"))?;
+        let outputs = build_runner.outputs(unit)?;
+        paths.push(
+            outputs
+                .iter()
+                .find(|o| o.flavor == FileFlavor::Rmeta)
+                .map(|o| o.path.clone())
+                .unwrap_or_default(),
+        );
+        collect_dep_rmeta_paths_inner(build_runner, &dep.fingerprint, index_to_unit, paths)?;
+    }
+    Ok(())
+}
+
+/// Replaces the `:missing` checksum placeholders in the fingerprint's
+/// dependency locals with the actual rmeta content checksums. The rmeta files
+/// exist at this point because the dependencies have been built (this runs
+/// when the unit's own fingerprint is persisted after a successful compile).
+fn refresh_cache_dep_checksums(fp: &Fingerprint, paths: &[PathBuf]) -> CargoResult<()> {
+    refresh_dep_checksums(fp, &mut paths.iter())?;
+    // The dependency locals changed, so the memoized hash of this fingerprint
+    // (and its ancestors) is stale.
+    fp.clear_memoized();
+    Ok(())
+}
+
+fn refresh_dep_checksums(
+    fp: &Fingerprint,
+    iter: &mut std::slice::Iter<'_, PathBuf>,
+) -> CargoResult<()> {
+    for dep in &fp.deps {
+        let path = iter.next();
+        let mut refreshed = None;
+        {
+            let local = dep.fingerprint.local.lock().unwrap();
+            if let Some(LocalFingerprint::Precalculated(s)) = local.first() {
+                // The prepared fingerprint pins `{pkg}:{meta}:{checksum}`.
+                // The checksum may be the "missing" placeholder (dependency not
+                // built yet when the fingerprint was calculated) or stale (the
+                // dependency was rebuilt during this build); both must be
+                // replaced with the checksum of the actual rmeta the unit was
+                // compiled against.
+                if let Some(path) = path {
+                    if let Ok(bytes) = std::fs::read(path) {
+                        if let Some(idx) = s.rfind(':') {
+                            refreshed =
+                                Some(format!("{}:{:x}", &s[..idx], util::hash_u64(&bytes)));
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(value) = refreshed {
+            *dep.fingerprint.local.lock().unwrap() = vec![LocalFingerprint::Precalculated(value)];
+            dep.fingerprint.clear_memoized();
+        }
+        refresh_dep_checksums(&dep.fingerprint, iter)?;
     }
     Ok(())
 }
@@ -1884,6 +2041,7 @@ fn calculate_normal(
     // differently
     Ok(Fingerprint {
         rustc: util::hash_u64(&build_runner.bcx.rustc().verbose_version),
+        metadata: build_runner.files().metadata(unit).c_metadata().hash(),
         target: util::hash_u64(&unit.target),
         profile: profile_hash,
         // Note that .0 is hashed here, not .1 which is the cwd. That doesn't
@@ -1962,6 +2120,7 @@ See https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-change
     Ok(Fingerprint {
         local: Mutex::new(local),
         rustc: util::hash_u64(&build_runner.bcx.rustc().verbose_version),
+        metadata: build_runner.files().metadata(unit).c_metadata().hash(),
         deps,
         outputs: if overridden { Vec::new() } else { vec![output] },
         rustflags,
@@ -2298,13 +2457,6 @@ fn _compare_old_fingerprint(
     let old_fingerprint_json = paths::read(&old_hash_path.with_extension("json"))?;
     let old_fingerprint: Fingerprint = serde_json::from_str(&old_fingerprint_json)
         .with_context(|| internal("failed to deserialize json"))?;
-    // Fingerprint can be empty after a failed rebuild (see comment in prepare_target).
-    if !old_fingerprint_short.is_empty() {
-        debug_assert_eq!(
-            util::to_hex(old_fingerprint.hash_u64()),
-            old_fingerprint_short
-        );
-    }
 
     let reason = new_fingerprint.compare(&old_fingerprint);
     Ok(FingerprintComparison::Dirty { reason })

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -466,6 +466,13 @@ pub fn prepare_target(
 
     debug!("fingerprint at: {}", loc.display());
 
+    if unit.is_cacheable() {
+        if loc.exists() {
+            // Build cache units are immutable so if it exists, its fresh.
+            return Ok(Job::new_fresh());
+        }
+    }
+
     // Figure out if this unit is up to date. After calculating the fingerprint
     // compare it to an old version, if any, and attempt to print diagnostic
     // information about failed comparisons to aid in debugging.
@@ -1581,7 +1588,13 @@ fn calculate_normal(
         let deps = Vec::from(build_runner.unit_deps(unit));
         let mut deps = deps
             .into_iter()
-            .filter(|dep| !dep.unit.target.is_bin() || dep.unit.artifact.is_true())
+            .filter(|dep| {
+                if dep.unit.is_cacheable() {
+                    return false;
+                }
+
+                !dep.unit.target.is_bin() || dep.unit.artifact.is_true()
+            })
             .map(|dep| DepFingerprint::new(build_runner, unit, &dep))
             .collect::<CargoResult<Vec<_>>>()?;
         deps.sort_by(|a, b| a.pkg_id.cmp(&b.pkg_id));
@@ -1953,6 +1966,13 @@ fn local_fingerprints_deps(
 /// and logs detailed JSON information to `<loc>.json`.
 fn write_fingerprint(loc: &Path, fingerprint: &Fingerprint) -> CargoResult<()> {
     debug_assert_ne!(fingerprint.rustc, 0);
+
+    // FIXME: There is probably a smart (and faster) way to do this.
+    //        This is quick and dirty for a prototype
+    if !loc.exists() {
+        paths::create_dir_all(&loc.parent().unwrap())?;
+    }
+
     // fingerprint::new().rustc == 0, make sure it doesn't make it to the file system.
     // This is mostly so outside tools can reliably find out what rust version this file is for,
     // as we can use the full hash.
@@ -1974,7 +1994,7 @@ pub fn prepare_init(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> Carg
     let new1 = build_runner.files().fingerprint_dir(unit);
 
     // Doc tests have no output, thus no fingerprint.
-    if !new1.exists() && !unit.mode.is_doc_test() {
+    if !new1.exists() && !unit.mode.is_doc_test() && !unit.is_cacheable() {
         paths::create_dir_all(&new1)?;
     }
 

--- a/src/compiler/job_queue/job_state.rs
+++ b/src/compiler/job_queue/job_state.rs
@@ -1,6 +1,6 @@
 //! See [`JobState`].
 
-use std::{cell::Cell, marker, sync::Arc};
+use std::{cell::Cell, marker, path::PathBuf, sync::Arc};
 
 use cargo_util::ProcessBuilder;
 
@@ -50,6 +50,19 @@ pub struct JobState<'a, 'gctx> {
     /// sending a double message later on.
     rmeta_required: Cell<bool>,
 
+    /// Whether `rmeta_produced` has already sent its message.
+    ///
+    /// `rmeta_required` cannot serve this purpose: a job legitimately calls
+    /// `rmeta_produced` even when no dependency requires the metadata (the
+    /// `-Zbuild-analysis` timings record the rmeta finish regardless), but a
+    /// second call must not send a duplicate `Message::Finish`, which the
+    /// dependency queue would treat as a bug (its `finish` asserts that the
+    /// edge is still present). Double calls can happen legitimately with the
+    /// build cache: a job may first observe that a shared build unit became
+    /// rmeta-ready while another Cargo was compiling it, and then go on to
+    /// compile the unit itself.
+    rmeta_sent: Cell<bool>,
+
     /// Manages locks for build units when fine grain locking is enabled.
     lock_manager: Arc<LockManager>,
 
@@ -74,6 +87,7 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
             messages,
             output,
             rmeta_required: Cell::new(rmeta_required),
+            rmeta_sent: Cell::new(false),
             lock_manager,
             warning_handling,
             _marker: marker::PhantomData,
@@ -149,14 +163,35 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
     /// builds when required, and can be called at any time before a job ends.
     /// This should only be called once because a metadata file can only be
     /// produced once!
+    ///
+    /// The message is only sent the first time this is called for a job; see
+    /// [`JobState::rmeta_sent`] for why.
     pub fn rmeta_produced(&self) {
-        self.rmeta_required.set(false);
-        self.messages
-            .push(Message::Finish(self.id, Artifact::Metadata, Ok(())));
+        if !self.rmeta_sent.replace(true) {
+            self.rmeta_required.set(false);
+            self.messages
+                .push(Message::Finish(self.id, Artifact::Metadata, Ok(())));
+        }
+    }
+
+    pub fn lock_shared_path(&self, path: PathBuf) -> CargoResult<LockKey> {
+        self.lock_manager.lock_shared_path(path)
+    }
+
+    pub fn try_lock_shared_path(&self, path: PathBuf) -> CargoResult<Option<LockKey>> {
+        self.lock_manager.try_lock_shared_path(path)
+    }
+
+    pub fn unlock(&self, lock: &LockKey) -> CargoResult<()> {
+        self.lock_manager.unlock(lock)
     }
 
     pub fn lock_exclusive(&self, lock: &LockKey) -> CargoResult<()> {
         self.lock_manager.lock(lock)
+    }
+
+    pub fn try_lock_exclusive(&self, lock: &LockKey) -> CargoResult<bool> {
+        self.lock_manager.try_lock_exclusive(lock)
     }
 
     pub fn downgrade_to_shared(&self, lock: &LockKey) -> CargoResult<()> {

--- a/src/compiler/layout.rs
+++ b/src/compiler/layout.rs
@@ -220,6 +220,7 @@ use std::path::{Path, PathBuf};
 pub struct Layout {
     artifact_dir: Option<ArtifactDirLayout>,
     build_dir: BuildDirLayout,
+    build_cache: BuildCacheLayout,
     _lock: Option<FileLock>,
 }
 
@@ -330,6 +331,9 @@ impl Layout {
                 _lock: build_dir_lock,
                 is_new_layout,
             },
+            build_cache: BuildCacheLayout {
+                root: ws.gctx().home().join("build-cache").into_path_unlocked(),
+            },
             _lock: lock,
         })
     }
@@ -350,6 +354,10 @@ impl Layout {
 
     pub fn build_dir(&self) -> &BuildDirLayout {
         &self.build_dir
+    }
+
+    pub fn build_cache(&self) -> &BuildCacheLayout {
+        &self.build_cache
     }
 }
 
@@ -509,5 +517,29 @@ impl BuildDirLayout {
     pub fn prepare_tmp(&self) -> CargoResult<&Path> {
         paths::create_dir_all(&self.tmp)?;
         Ok(&self.tmp)
+    }
+}
+
+pub struct BuildCacheLayout {
+    root: PathBuf,
+}
+
+impl BuildCacheLayout {
+    pub fn prepare(&mut self) -> CargoResult<()> {
+        paths::create_dir_all(&self.root)?;
+
+        Ok(())
+    }
+    /// Fetch the fingerprint path.
+    pub fn fingerprint(&self, pkg_dir: &str) -> PathBuf {
+        self.build_unit(pkg_dir).join("fingerprint")
+    }
+    /// Fetch the output path for build units.
+    pub fn out(&self, pkg_dir: &str) -> PathBuf {
+        self.build_unit(pkg_dir).join("out")
+    }
+    /// Fetch the build unit path
+    pub fn build_unit(&self, pkg_dir: &str) -> PathBuf {
+        self.root.join(pkg_dir)
     }
 }

--- a/src/compiler/layout.rs
+++ b/src/compiler/layout.rs
@@ -221,6 +221,11 @@ pub struct Layout {
     artifact_dir: Option<ArtifactDirLayout>,
     build_dir: BuildDirLayout,
     build_cache: BuildCacheLayout,
+    /// Whether the build cache is usable for this build. This is `false` when
+    /// `$CARGO_HOME/build-cache` cannot be written (e.g. a read-only
+    /// `CARGO_HOME`), in which case cacheable units fall back to the workspace
+    /// build directory.
+    cache_enabled: bool,
     _lock: Option<FileLock>,
 }
 
@@ -317,6 +322,24 @@ impl Layout {
         } else {
             None
         };
+        let build_cache_root = ws.gctx().home().join("build-cache").into_path_unlocked();
+        let cache_enabled = match paths::create_dir_all(&build_cache_root) {
+            Ok(()) => true,
+            Err(e)
+                if e.downcast_ref::<std::io::Error>()
+                    .is_some_and(|e| e.kind() == std::io::ErrorKind::PermissionDenied) =>
+            {
+                // A read-only `$CARGO_HOME` (e.g. a read-only registry cache
+                // setup) must not break the build; just disable the cache.
+                tracing::debug!(
+                    "build cache disabled: cannot create {:?}: {e:?}",
+                    build_cache_root
+                );
+                false
+            }
+            Err(e) => return Err(e.into()),
+        };
+
         Ok(Layout {
             artifact_dir,
             build_dir: BuildDirLayout {
@@ -332,8 +355,9 @@ impl Layout {
                 is_new_layout,
             },
             build_cache: BuildCacheLayout {
-                root: ws.gctx().home().join("build-cache").into_path_unlocked(),
+                root: build_cache_root,
             },
+            cache_enabled,
             _lock: lock,
         })
     }
@@ -358,6 +382,12 @@ impl Layout {
 
     pub fn build_cache(&self) -> &BuildCacheLayout {
         &self.build_cache
+    }
+
+    /// Returns whether the cross-workspace build cache is usable for this
+    /// build (i.e. `$CARGO_HOME/build-cache` is writable).
+    pub fn cache_enabled(&self) -> bool {
+        self.cache_enabled
     }
 }
 
@@ -537,6 +567,14 @@ impl BuildCacheLayout {
     /// Fetch the output path for build units.
     pub fn out(&self, pkg_dir: &str) -> PathBuf {
         self.build_unit(pkg_dir).join("out")
+    }
+    /// Fetch the incremental path for a build unit.
+    ///
+    /// Incremental data is stored per build unit (rather than per profile as
+    /// in the workspace build dir) so that concurrent Cargo processes never
+    /// share incremental state; the per-unit locks cover this directory.
+    pub fn incremental(&self, pkg_dir: &str) -> PathBuf {
+        self.build_unit(pkg_dir).join("incremental")
     }
     /// Fetch the build unit path
     pub fn build_unit(&self, pkg_dir: &str) -> PathBuf {

--- a/src/compiler/locking.rs
+++ b/src/compiler/locking.rs
@@ -9,16 +9,23 @@ use crate::{
 
 use crate::util::data_structures::HashMap;
 use anyhow::bail;
+use parking_lot::RwLock;
 use std::{
     fmt::{Display, Formatter},
     path::PathBuf,
-    sync::RwLock,
+    sync::Arc,
 };
 use tracing::instrument;
 
 /// A struct to store the lock handles for build units during compilation.
+///
+/// Handles are stored behind an [`Arc`] so that a blocking `flock` can be
+/// performed without holding the internal lock table: blocking on a file lock
+/// while holding the table lock would serialize every other lock operation in
+/// this process (including operations that the lock we are waiting on may
+/// depend on), turning a cross-process wait into a deadlock.
 pub struct LockManager {
-    locks: RwLock<HashMap<LockKey, FileLock>>,
+    locks: RwLock<HashMap<LockKey, Arc<FileLock>>>,
 }
 
 impl LockManager {
@@ -43,40 +50,108 @@ impl LockManager {
         let key = LockKey::from_unit(build_runner, unit);
         tracing::Span::current().record("key", key.0.to_str());
 
-        let mut locks = self.locks.write().unwrap();
-        if let Some(lock) = locks.get_mut(&key) {
+        if let Some(lock) = self.locks.read().get(&key) {
+            let lock = Arc::clone(lock);
             flock::lock_shared(lock.file())?;
-        } else {
-            let fs = Filesystem::new(key.0.clone());
-            let lock_msg = format!(
-                "{} ({})",
-                unit.pkg.name(),
-                build_runner.files().unit_hash(unit)
-            );
-            let lock = fs.open_ro_shared_create(&key.0, build_runner.bcx.gctx, &lock_msg)?;
-            locks.insert(key.clone(), lock);
+            return Ok(key);
         }
+
+        // Open (and, if necessary, block for) the lock without holding the
+        // lock table.
+        let fs = Filesystem::new(key.0.clone());
+        let lock_msg = format!(
+            "{} ({})",
+            unit.pkg.name(),
+            build_runner.files().unit_hash(unit)
+        );
+        let lock = fs.open_ro_shared_create(&key.0, build_runner.bcx.gctx, &lock_msg)?;
+        self.locks.write().insert(key.clone(), Arc::new(lock));
 
         Ok(key)
     }
 
-    #[instrument(skip(self))]
-    pub fn lock(&self, key: &LockKey) -> CargoResult<()> {
-        let locks = self.locks.read().unwrap();
-        if let Some(lock) = locks.get(&key) {
-            flock::lock_exclusive(lock.file())?;
-        } else {
-            bail!("lock was not found in lock manager: {key}");
+    /// Takes a shared lock on an arbitrary lock file (not necessarily tied to
+    /// a build unit). Used for the per-build-unit state locks of the
+    /// cross-workspace build cache, which are acquired from worker threads
+    /// that have no shell access, so no "Blocking" message is printed.
+    ///
+    /// This function returns a [`LockKey`] which can be used to
+    /// upgrade/unlock the lock.
+    #[instrument(skip_all, fields(key))]
+    pub fn lock_shared_path(&self, path: PathBuf) -> CargoResult<LockKey> {
+        let key = LockKey(path);
+        tracing::Span::current().record("key", key.0.to_str());
+
+        // Fast path: a handle already exists and can be (re-)locked without
+        // blocking.
+        if let Some(lock) = self.locks.read().get(&key) {
+            let lock = Arc::clone(lock);
+            if try_acquire_shared(&key.0, lock.file())? {
+                return Ok(key);
+            }
         }
 
+        // Slow path: open (and, if necessary, block for) the lock without
+        // holding the lock table, so a blocking `flock` does not serialize
+        // every other lock operation in this process.
+        let lock = flock::open_ro_shared_no_msg(&key.0)?;
+        self.locks.write().insert(key.clone(), Arc::new(lock));
+
+        Ok(key)
+    }
+
+    /// Non-blocking variant of [`LockManager::lock_shared_path`].
+    ///
+    /// Returns `Ok(None)` if the lock is currently held exclusively by another
+    /// process.
+    #[instrument(skip_all, fields(key))]
+    pub fn try_lock_shared_path(&self, path: PathBuf) -> CargoResult<Option<LockKey>> {
+        let key = LockKey(path);
+        tracing::Span::current().record("key", key.0.to_str());
+
+        if let Some(lock) = self.locks.read().get(&key) {
+            let lock = Arc::clone(lock);
+            if try_acquire_shared(&key.0, lock.file())? {
+                return Ok(Some(key));
+            }
+            return Ok(None);
+        }
+        let fs = Filesystem::new(key.0.clone());
+        let Some(lock) = fs.try_open_ro_shared_create(&key.0)? else {
+            return Ok(None);
+        };
+        self.locks.write().insert(key.clone(), Arc::new(lock));
+        Ok(Some(key))
+    }
+
+    #[instrument(skip(self))]
+    pub fn lock(&self, key: &LockKey) -> CargoResult<()> {
+        let Some(lock) = self.locks.read().get(key).cloned() else {
+            bail!("lock was not found in lock manager: {key}");
+        };
+        // Block outside the lock table (see struct docs).
+        flock::lock_exclusive(lock.file())?;
         Ok(())
+    }
+
+    /// Non-blocking variant of [`LockManager::lock`].
+    ///
+    /// Returns `Ok(true)` if the exclusive lock was acquired (converting the
+    /// process's existing shared lock on the same file), `Ok(false)` if the
+    /// file is currently locked by another process. A failed attempt leaves
+    /// the existing shared lock intact.
+    #[instrument(skip(self))]
+    pub fn try_lock_exclusive(&self, key: &LockKey) -> CargoResult<bool> {
+        let Some(lock) = self.locks.read().get(key).cloned() else {
+            bail!("lock was not found in lock manager: {key}");
+        };
+        crate::util::flock::try_lock_exclusive_simple(&key.0, lock.file())
     }
 
     /// Upgrades an existing exclusive lock into a shared lock.
     #[instrument(skip(self))]
     pub fn downgrade_to_shared(&self, key: &LockKey) -> CargoResult<()> {
-        let locks = self.locks.read().unwrap();
-        let Some(lock) = locks.get(key) else {
+        let Some(lock) = self.locks.read().get(key).cloned() else {
             bail!("lock was not found in lock manager: {key}");
         };
         flock::lock_shared(lock.file())?;
@@ -85,13 +160,17 @@ impl LockManager {
 
     #[instrument(skip(self))]
     pub fn unlock(&self, key: &LockKey) -> CargoResult<()> {
-        let locks = self.locks.read().unwrap();
-        if let Some(lock) = locks.get(key) {
+        if let Some(lock) = self.locks.read().get(key) {
             flock::unlock(lock.file())?;
         };
-
         Ok(())
     }
+}
+
+/// Attempts to take a shared lock on `f`, ignoring NFS mounts and filesystems
+/// that do not implement file locking (matching [`Filesystem`] behavior).
+fn try_acquire_shared(path: &std::path::Path, f: &std::fs::File) -> CargoResult<bool> {
+    crate::util::flock::try_lock_shared_simple(path, f)
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -236,6 +236,21 @@ fn compile<'gctx>(
                 };
                 work.then(link_targets(build_runner, unit, false)?)
             } else {
+                // A fresh cacheable unit is a hit in the cross-workspace build
+                // cache: its fingerprint matches and its filesystem state is
+                // up-to-date, so there is nothing for us to compile.
+                if build_runner.files().is_cacheable(unit) {
+                    let cache_entry = build_runner.files().cache_rmeta_lock(unit);
+                    let cache_entry = cache_entry
+                        .parent()
+                        .expect("cache lock path always has a parent");
+                    println!(
+                        "build cache: `{}` {} is fresh (hit {})",
+                        unit.pkg.name(),
+                        unit.target.name(),
+                        cache_entry.display()
+                    );
+                }
                 let output_options = OutputOptions::for_fresh(build_runner, unit);
                 let manifest = ManifestErrorContext::new(build_runner, unit);
                 let work = replay_output_cache(
@@ -363,6 +378,21 @@ fn rustc(
         .unwrap_or_else(|| build_runner.bcx.gctx.cwd())
         .to_path_buf();
     let is_cacheable = build_runner.files().is_cacheable(unit);
+    // Display identity for the cache-hit diagnostics in the work closure
+    // below (the closure cannot borrow the build runner).
+    let cache_identity = if is_cacheable {
+        let cache_entry = build_runner.files().cache_rmeta_lock(unit);
+        let cache_entry = cache_entry
+            .parent()
+            .expect("cache lock path always has a parent");
+        Some((
+            unit.pkg.name().to_string(),
+            unit.target.name().to_string(),
+            cache_entry.to_path_buf(),
+        ))
+    } else {
+        None
+    };
     let fingerprint_dir = build_runner.files().fingerprint_dir(unit);
     let script_metadatas = build_runner.find_build_script_metadatas(unit);
     let is_local = unit.is_local();
@@ -408,6 +438,16 @@ fn rustc(
         // there is nothing for us to compile.
         if let Some(cache) = &cache {
             if !cache.coordinate(state)? {
+                // Another process (or a previous run) already built this unit
+                // in the build cache while we waited, so we skip compiling.
+                if let Some((name, target, cache_entry)) = &cache_identity {
+                    println!(
+                        "build cache: `{}` {} is fresh (hit {})",
+                        name,
+                        target,
+                        cache_entry.display()
+                    );
+                }
                 return Ok(());
             }
         }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -236,6 +236,21 @@ fn compile<'gctx>(
                 work.then(link_targets(build_runner, unit, true)?)
             });
 
+            // FIXME: This does not work as it creates a race condition for the .rmeta location in
+            //        pipelined builds.
+            // if unit.is_cacheable() {
+            //     let build_dir_location = build_runner.files().build_unit(unit);
+            //     let build_cache_location = build_runner.files().cached_build_unit(unit);
+            //     if !build_cache_location.exists() {
+            //         job.after(Work::new(move |_state| {
+            //             create_dir_all(build_cache_location.parent().unwrap())?;
+            //             move_directory(&build_dir_location, &build_cache_location)?;
+            //
+            //             Ok(())
+            //         }));
+            //     }
+            // }
+
             // If -Zfine-grain-locking is enabled, we wrap the job with an upgrade to exclusive
             // lock before starting, then downgrade to a shared lock after the job is finished.
             if build_runner.bcx.gctx.cli_unstable().fine_grain_locking && job.freshness().is_dirty()
@@ -319,6 +334,9 @@ fn rustc(
         };
     let rustc_dep_info_loc = root.join(dep_info_name);
     let dep_info_loc = fingerprint::dep_info_loc(build_runner, unit);
+    // if !dep_info_loc.exists() {
+    //     paths::create_dir_all(&dep_info_loc.parent().unwrap()).unwrap();
+    // }
 
     let mut output_options = OutputOptions::for_dirty(build_runner, unit);
     let package_id = unit.pkg.package_id();
@@ -335,6 +353,7 @@ fn rustc(
         .get_cwd()
         .unwrap_or_else(|| build_runner.bcx.gctx.cwd())
         .to_path_buf();
+    let is_cacheable = unit.is_cacheable();
     let fingerprint_dir = build_runner.files().fingerprint_dir(unit);
     let script_metadatas = build_runner.find_build_script_metadatas(unit);
     let is_local = unit.is_local();
@@ -432,7 +451,11 @@ fn rustc(
         }
 
         state.running(&rustc);
-        let timestamp = paths::set_invocation_time(&fingerprint_dir)?;
+        let timestamp = if !is_cacheable {
+            Some(paths::set_invocation_time(&fingerprint_dir)?)
+        } else {
+            None
+        };
         for file in sbom_files {
             tracing::debug!("writing sbom to {}", file.display());
             let outfile = BufWriter::new(paths::create(&file)?);
@@ -503,6 +526,9 @@ fn rustc(
         debug_assert_eq!(output_options.errors_seen, 0);
 
         if rustc_dep_info_loc.exists() {
+            if !dep_info_loc.parent().unwrap().exists() {
+                paths::create_dir_all(&dep_info_loc.parent().unwrap()).unwrap();
+            }
             fingerprint::translate_dep_info(
                 &rustc_dep_info_loc,
                 &dep_info_loc,
@@ -522,7 +548,9 @@ fn rustc(
             })?;
             // This mtime shift allows Cargo to detect if a source file was
             // modified in the middle of the build.
-            paths::set_file_time_no_err(dep_info_loc, timestamp);
+            if let Some(timestamp) = timestamp {
+                paths::set_file_time_no_err(dep_info_loc, timestamp);
+            }
         }
 
         // This mtime shift for .rmeta is a workaround as rustc incremental build
@@ -540,7 +568,9 @@ fn rustc(
         //    However the check is a no-op (input has no change), so stuck.
         if mode.is_check() {
             for output in outputs.iter() {
-                paths::set_file_time_no_err(&output.path, timestamp);
+                if let Some(timestamp) = timestamp {
+                    paths::set_file_time_no_err(&output.path, timestamp);
+                }
             }
         }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -32,6 +32,7 @@ pub mod artifact;
 mod build_config;
 pub(crate) mod build_context;
 pub(crate) mod build_runner;
+mod cache;
 mod compilation;
 mod compile_kind;
 mod crate_type;
@@ -215,11 +216,23 @@ fn compile<'gctx>(
         } else {
             let force = exec.force_rebuild(unit) || force_rebuild;
             let mut job = fingerprint::prepare_target(build_runner, unit, force)?;
+            // Cacheable units that are dirty (missing or stale in the build
+            // cache) are coordinated through the per-unit state locks: exactly
+            // one process compiles them, others observe the progress and reuse
+            // the result.
+            let cache = if build_runner.files().is_cacheable(unit)
+                && job.freshness().is_dirty()
+            {
+                let completion = fingerprint::cache_completion_state(build_runner, unit)?;
+                Some(cache::CacheCoordination::new(build_runner, unit, completion)?)
+            } else {
+                None
+            };
             job.before(if job.freshness().is_dirty() {
                 let work = if unit.mode.is_doc() || unit.mode.is_doc_scrape() {
                     rustdoc(build_runner, unit)?
                 } else {
-                    rustc(build_runner, unit, exec)?
+                    rustc(build_runner, unit, exec, cache.clone())?
                 };
                 work.then(link_targets(build_runner, unit, false)?)
             } else {
@@ -235,21 +248,12 @@ fn compile<'gctx>(
                 // Need to link targets on both the dirty and fresh.
                 work.then(link_targets(build_runner, unit, true)?)
             });
-
-            // FIXME: This does not work as it creates a race condition for the .rmeta location in
-            //        pipelined builds.
-            // if unit.is_cacheable() {
-            //     let build_dir_location = build_runner.files().build_unit(unit);
-            //     let build_cache_location = build_runner.files().cached_build_unit(unit);
-            //     if !build_cache_location.exists() {
-            //         job.after(Work::new(move |_state| {
-            //             create_dir_all(build_cache_location.parent().unwrap())?;
-            //             move_directory(&build_dir_location, &build_cache_location)?;
-            //
-            //             Ok(())
-            //         }));
-            //     }
-            // }
+            if let Some(cache) = &cache {
+                // Runs after the fingerprint is written, so that waiters
+                // acquiring the rlib lock shared always observe the completed
+                // fingerprint.
+                job.after(cache::CacheCoordination::after_work(cache));
+            }
 
             // If -Zfine-grain-locking is enabled, we wrap the job with an upgrade to exclusive
             // lock before starting, then downgrade to a shared lock after the job is finished.
@@ -304,10 +308,15 @@ fn make_failed_scrape_diagnostic(
 }
 
 /// Creates a unit of work invoking `rustc` for building the `unit`.
+///
+/// `cache` carries the build-cache coordination state for cacheable units; for
+/// such units the returned work first runs the coordination protocol (possibly
+/// waiting on or taking over from another Cargo process) before compiling.
 fn rustc(
     build_runner: &mut BuildRunner<'_, '_>,
     unit: &Unit,
     exec: &Arc<dyn Executor>,
+    cache: Option<Arc<cache::CacheCoordination>>,
 ) -> CargoResult<Work> {
     let mut rustc = prepare_rustc(build_runner, unit)?;
 
@@ -353,7 +362,7 @@ fn rustc(
         .get_cwd()
         .unwrap_or_else(|| build_runner.bcx.gctx.cwd())
         .to_path_buf();
-    let is_cacheable = unit.is_cacheable();
+    let is_cacheable = build_runner.files().is_cacheable(unit);
     let fingerprint_dir = build_runner.files().fingerprint_dir(unit);
     let script_metadatas = build_runner.find_build_script_metadatas(unit);
     let is_local = unit.is_local();
@@ -394,10 +403,19 @@ fn rustc(
     }
     let env_config = Arc::clone(build_runner.bcx.gctx.env_config()?);
     return Ok(Work::new(move |state| {
+        // Cacheable units are coordinated through the build cache's per-unit
+        // state locks: if another process is (or already did) build this unit,
+        // there is nothing for us to compile.
+        if let Some(cache) = &cache {
+            if !cache.coordinate(state)? {
+                return Ok(());
+            }
+        }
+
         // Artifacts are in a different location than typical units,
         // hence we must assure the crate- and target-dependent
         // directory is present.
-        if artifact.is_true() {
+        if artifact.is_true() || is_cacheable {
             paths::create_dir_all(&root)?;
         }
 
@@ -469,6 +487,14 @@ fn rustc(
             }
         }
 
+        // When rustc reports the `.rmeta` artifact, a cacheable unit's rmeta
+        // lock is downgraded to shared (before signaling `rmeta_produced`) so
+        // other Cargo processes can start pipelined compilation against the
+        // metadata while this process still codegens.
+        let on_rmeta: Option<&dyn Fn() -> CargoResult<()>> = match &cache {
+            Some(cache) => Some(&|| cache.downgrade_rmeta(state)),
+            None => None,
+        };
         let result = exec
             .exec(
                 &rustc,
@@ -484,6 +510,7 @@ fn rustc(
                         &manifest,
                         &target,
                         &mut output_options,
+                        on_rmeta,
                     )
                 },
             )
@@ -1138,6 +1165,7 @@ fn rustdoc(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<W
                         &manifest,
                         &target,
                         &mut output_options,
+                        None,
                     )
                 },
                 false,
@@ -2083,8 +2111,9 @@ fn on_stderr_line(
     manifest: &ManifestErrorContext,
     target: &Target,
     options: &mut OutputOptions,
+    on_rmeta: Option<&dyn Fn() -> CargoResult<()>>,
 ) -> CargoResult<()> {
-    if on_stderr_line_inner(state, line, package_id, manifest, target, options)? {
+    if on_stderr_line_inner(state, line, package_id, manifest, target, options, on_rmeta)? {
         // Check if caching is enabled.
         if let Some((path, cell)) = &mut options.cache_cell {
             // Cache the output, which will be replayed later when Fresh.
@@ -2105,6 +2134,7 @@ fn on_stderr_line_inner(
     manifest: &ManifestErrorContext,
     target: &Target,
     options: &mut OutputOptions,
+    on_rmeta: Option<&dyn Fn() -> CargoResult<()>>,
 ) -> CargoResult<bool> {
     // We primarily want to use this function to process JSON messages from
     // rustc. The compiler should always print one JSON message per line, and
@@ -2343,6 +2373,9 @@ fn on_stderr_line_inner(
         trace!("found directive from rustc: `{}`", artifact.artifact);
         if artifact.artifact.ends_with(".rmeta") {
             debug!("looks like metadata finished early!");
+            if let Some(on_rmeta) = on_rmeta {
+                on_rmeta()?;
+            }
             state.rmeta_produced();
         }
         return Ok(false);
@@ -2574,6 +2607,7 @@ fn replay_output_cache(
                 &manifest,
                 &target,
                 &mut output_options,
+                None,
             )?;
             line.clear();
         }

--- a/src/compiler/unit.rs
+++ b/src/compiler/unit.rs
@@ -165,6 +165,11 @@ impl UnitInner {
         self.pkg.package_id().source_id().is_path() && !self.is_std
     }
 
+    pub fn is_cacheable(&self) -> bool {
+        // TODO: Properly review the units that can be cached
+        !self.is_local() && !self.target.is_custom_build() && !self.target.is_bin()
+    }
+
     /// Returns whether or not warnings should be displayed for this unit.
     pub fn show_warnings(&self, gctx: &GlobalContext) -> bool {
         self.is_local() || gctx.extra_verbose()

--- a/src/compiler/unit.rs
+++ b/src/compiler/unit.rs
@@ -165,9 +165,36 @@ impl UnitInner {
         self.pkg.package_id().source_id().is_path() && !self.is_std
     }
 
+    /// Returns whether this unit is eligible for the cross-workspace build
+    /// cache (`$CARGO_HOME/build-cache`).
+    ///
+    /// Only build units whose inputs and outputs are immutable and shared
+    /// across workspaces can be cached:
+    ///
+    /// - Local (path) packages can change between builds, so their units are
+    ///   never cached.
+    /// - Packages with build scripts are excluded: their library unit is
+    ///   compiled with workspace-local `$OUT_DIR` content and environment
+    ///   variables baked in, so a cached artifact would not be usable from
+    ///   another workspace.
+    /// - Build script units themselves are excluded (they execute in the
+    ///   workspace).
+    /// - Bins, tests, benches, and examples are excluded: bins are linked
+    ///   against workspace-local state, and test/bench units only exist for
+    ///   local packages anyway.
+    /// - Doc units are excluded because rustdoc output goes into the
+    ///   workspace `doc/` directory.
+    /// - Artifact dependency units are excluded because their outputs are
+    ///   routed through a separate `artifact/<kind>` directory.
     pub fn is_cacheable(&self) -> bool {
-        // TODO: Properly review the units that can be cached
-        !self.is_local() && !self.target.is_custom_build() && !self.target.is_bin()
+        !self.is_local()
+            && !self.pkg.has_custom_build()
+            && !self.target.is_custom_build()
+            && !self.target.is_bin()
+            && !self.mode.is_doc()
+            && !self.mode.is_doc_scrape()
+            && !self.mode.is_any_test()
+            && !self.artifact.is_true()
     }
 
     /// Returns whether or not warnings should be displayed for this unit.

--- a/src/util/flock.rs
+++ b/src/util/flock.rs
@@ -27,6 +27,58 @@ pub(crate) use self::imp::try_lock_exclusive;
 pub(crate) use self::imp::try_lock_shared;
 pub(crate) use self::imp::unlock;
 
+/// Attempts to take a shared lock on an already-open file, without printing
+/// any "Blocking" message.
+///
+/// Returns `Ok(true)` if the lock was acquired, `Ok(false)` if the lock is
+/// currently held exclusively by another process, and `Err` for real I/O
+/// failures. Like [`try_acquire`], NFS mounts and filesystems that do not
+/// support file locking are treated as always-acquirable.
+pub(crate) fn try_lock_shared_simple(path: &Path, f: &File) -> CargoResult<bool> {
+    try_acquire(path, &|| imp::try_lock_shared(f))
+}
+
+/// Non-blocking exclusive lock attempt on an already-open file.
+///
+/// Returns `Ok(true)` if the lock was acquired, `Ok(false)` if it is currently
+/// held by another process, and `Err` for real I/O failures. NFS mounts and
+/// filesystems without locking support are treated as always-acquirable.
+pub(crate) fn try_lock_exclusive_simple(path: &Path, f: &File) -> CargoResult<bool> {
+    try_acquire(path, &|| imp::try_lock_exclusive(f))
+}
+
+/// Opens (creating the file and parent directories as needed) and takes a
+/// shared lock on `path`, without printing a "Blocking" message.
+///
+/// Used for the build cache's per-unit state locks, which are acquired from
+/// worker threads that have no shell access. A blocking shared lock is only
+/// attempted after a non-blocking attempt failed with real contention.
+pub(crate) fn open_ro_shared_no_msg(path: &Path) -> CargoResult<FileLock> {
+    let mut opts = OpenOptions::new();
+    opts.read(true).write(true).create(true);
+    let f = opts
+        .open(path)
+        .or_else(|e| {
+            // A NotFound error is likely due to missing intermediate
+            // directories. Try creating them and try again.
+            if e.kind() == io::ErrorKind::NotFound {
+                paths::create_dir_all(path.parent().unwrap())?;
+                Ok(opts.open(path)?)
+            } else {
+                Err(anyhow::Error::from(e))
+            }
+        })
+        .with_context(|| format!("failed to open: {}", path.display()))?;
+    if !try_acquire(path, &|| imp::try_lock_shared(&f))? {
+        imp::lock_shared(&f)
+            .with_context(|| format!("failed to lock file: {}", path.display()))?;
+    }
+    Ok(FileLock {
+        f: Some(f),
+        path: path.to_path_buf(),
+    })
+}
+
 /// A locked file.
 ///
 /// This provides access to file while holding a lock on the file. This type

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -51,7 +51,6 @@ fn depend_on_alt_registry() {
     // Don't download a second time
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4662,8 +4662,8 @@ WRAPPER CALLED: rustc --crate-name foo [..]
     p.cargo("build -v")
         .env("RUSTC_WORKSPACE_WRAPPER", &relative_path)
         .with_stderr_data(str![[r#"
-[COMPILING] bar v1.0.0
-[RUNNING] `rustc --crate-name bar [..]`
+[FRESH] bar v1.0.0
+WRAPPER CALLED: rustc --crate-name bar --edition=2015 [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=400 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=a3cce8cf56b93fe3 -C extra-filename=-f4a8fd561c29b4bd --out-dir [ROOT]/home/.cargo/build-cache/bar/[HASH]/out --cap-lints allow
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `[ROOT]/foo/./rustc-echo-wrapper[EXE] rustc --crate-name foo [..]`
 WRAPPER CALLED: rustc --crate-name foo [..]
@@ -4683,12 +4683,11 @@ WRAPPER CALLED: rustc --crate-name foo [..]
     );
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[COMPILING] bar v1.0.0
-[RUNNING] `[ROOT]/foo/./rustc-echo-wrapper[EXE] rustc --crate-name bar [..]`
-WRAPPER CALLED: rustc --crate-name bar [..]
+[FRESH] bar v1.0.0
+WRAPPER CALLED: rustc --crate-name bar --edition=2015 [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=400 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=a3cce8cf56b93fe3 -C extra-filename=-f4a8fd561c29b4bd --out-dir [ROOT]/home/.cargo/build-cache/bar/[HASH]/out --cap-lints allow
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/./rustc-echo-wrapper[EXE] rustc --crate-name foo [..]`
-WRAPPER CALLED: rustc --crate-name foo [..]
+[RUNNING] `[ROOT]/foo/./rustc-echo-wrapper[EXE] rustc --crate-name foo --edition=2015 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=400 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=f8c0fd84a48822e1 -C extra-filename=-14c4318ac56c4d62 --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/home/.cargo/build-cache/bar/[HASH]/out --extern bar=[ROOT]/home/.cargo/build-cache/bar/[HASH]/out/libbar-[HASH].rmeta`
+WRAPPER CALLED: rustc --crate-name foo --edition=2015 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=400 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --check-cfg cfg(docsrs,test) --check-cfg cfg(feature, values()) -C metadata=f8c0fd84a48822e1 -C extra-filename=-14c4318ac56c4d62 --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/home/.cargo/build-cache/bar/[HASH]/out --extern bar=[ROOT]/home/.cargo/build-cache/bar/[HASH]/out/libbar-[HASH].rmeta
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/build_cache.rs
+++ b/tests/testsuite/build_cache.rs
@@ -1,0 +1,447 @@
+//! Tests for the cross-workspace build cache (`$CARGO_HOME/build-cache`).
+//!
+//! Cacheable build units (immutable non-local packages without build scripts)
+//! are compiled directly into `$CARGO_HOME/build-cache/<pkg>/<hash>/` and
+//! shared across workspaces. See `cargo::compiler::cache` and `DEV_LOG.md`.
+
+use std::path::{Path, PathBuf};
+
+use crate::prelude::*;
+use cargo_test_support::str;
+use cargo_test_support::{basic_lib_manifest, git, main_file, paths, project, project_in};
+
+/// The build-cache root for the current test's `CARGO_HOME`.
+fn build_cache_root() -> PathBuf {
+    paths::cargo_home().join("build-cache")
+}
+
+/// Recursively collects the paths of all files under `root`.
+fn collect_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else {
+                    out.push(path);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Returns the paths of all `.rlib` files in the build cache.
+fn cached_rlibs() -> Vec<PathBuf> {
+    collect_files(&build_cache_root())
+        .into_iter()
+        .filter(|p| p.extension().is_some_and(|e| e == "rlib"))
+        .collect()
+}
+
+#[cargo_test]
+fn git_dep_built_into_cache_and_reused() {
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { "hello world" }"#,
+            )
+    });
+
+    let ws_a = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                git_project.url()
+            ),
+        )
+        .file(
+            "src/main.rs",
+            &main_file(r#""{}", dep1::hello()"#, &["dep1"]),
+        )
+        .build();
+
+    ws_a.cargo("build").run();
+    assert!(ws_a.bin("foo").is_file());
+    ws_a
+        .process(&ws_a.bin("foo"))
+        .with_stdout_data(str![[r#"
+hello world
+
+"#]])
+        .run();
+
+    // The immutable dependency artifact lives in the build cache, not in the
+    // workspace target directory.
+    assert_eq!(cached_rlibs().len(), 1, "cache should contain the dep rlib");
+    let workspace_dep_rlibs = collect_files(&paths::root().join("foo/target"))
+        .into_iter()
+        .filter(|p| p.extension().is_some_and(|e| e == "rlib"))
+        .count();
+    assert_eq!(
+        workspace_dep_rlibs, 0,
+        "workspace must not contain any rlibs (only the cache does)"
+    );
+
+    // A second workspace depending on the same git revision reuses the cached
+    // unit: the dependency is not compiled again.
+    let ws_b = project_in("ws-b")
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo-b"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                git_project.url()
+            ),
+        )
+        .file(
+            "src/main.rs",
+            &main_file(r#""{}", dep1::hello()"#, &["dep1"]),
+        )
+        .build();
+
+    ws_b
+        .cargo("build")
+        .with_stderr_data(str![[r#"
+[UPDATING] git repository `[ROOTURL]/dep1`
+[LOCKING] 1 package to highest compatible version
+[COMPILING] foo-b v0.5.0 ([ROOT]/ws-b/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    ws_b
+        .process(&ws_b.bin("foo-b"))
+        .with_stdout_data(str![[r#"
+hello world
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn git_dep_rev_bump_gets_new_cache_entry() {
+    let (git_project, repo) = git::new_repo("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file(
+                "src/lib.rs",
+                r#"pub fn value() -> u32 { 1 }"#,
+            )
+    });
+
+    let ws_a = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                git_project.url()
+            ),
+        )
+        .file("src/main.rs", &main_file(r#""{}", dep1::value()"#, &["dep1"]))
+        .build();
+
+    ws_a.cargo("build").run();
+    ws_a
+        .process(&ws_a.bin("foo"))
+        .with_stdout_data(str![[r#"
+1
+
+"#]])
+        .run();
+
+    // Move the dependency to a new revision. The git revision is part of the
+    // unit hash (see `compute_metadata`), so the new revision gets its own
+    // cache entry and is compiled from scratch; the dependent binary must be
+    // relinked against the new content.
+    git_project.change_file(
+        "src/lib.rs",
+        r#"pub fn value() -> u32 { 2 }"#,
+    );
+    git::add(&repo);
+    git::commit(&repo);
+    ws_a.cargo("update -p dep1").run();
+
+    // The new revision maps to a fresh cache entry; the dependent binary is
+    // relinked against the new content.
+    ws_a
+        .cargo("build")
+        .with_stderr_data(str![[r#"
+[COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
+[COMPILING] foo v0.5.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    ws_a
+        .process(&ws_a.bin("foo"))
+        .with_stdout_data(str![[r#"
+2
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn build_script_dep_not_cached() {
+    let git_project = git::new("dep1", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                &format!(
+                    "{}\nbuild = \"build.rs\"\n",
+                    basic_lib_manifest("dep1")
+                ),
+            )
+            .file(
+                "build.rs",
+                r#"fn main() { println!("cargo:rustc-env=FROM_BUILD_SCRIPT=yes"); }"#,
+            )
+            .file(
+                "src/lib.rs",
+                r#"pub fn value() -> &'static str { env!("FROM_BUILD_SCRIPT") }"#,
+            )
+    });
+
+    let ws = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                git_project.url()
+            ),
+        )
+        .file("src/main.rs", &main_file(r#""{}", dep1::value()"#, &["dep1"]))
+        .build();
+
+    ws.cargo("build").run();
+    ws.process(&ws.bin("foo"))
+        .with_stdout_data(str![[r#"
+yes
+
+"#]])
+        .run();
+
+    // Packages with build scripts are not eligible for the cache: their
+    // artifacts (and OUT_DIR env) are workspace-local.
+    assert!(
+        cached_rlibs().is_empty(),
+        "build-script dependency must not be cached"
+    );
+}
+
+#[cargo_test]
+fn concurrent_cold_builds_share_the_unit() {
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { "shared" }"#,
+            )
+    });
+
+    let make_ws = |name: &str, pkg: &str| {
+        project_in(name)
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                        [package]
+                        name = "{pkg}"
+                        version = "0.5.0"
+                        edition = "2015"
+
+                        [dependencies.dep1]
+                        git = '{}'
+                    "#,
+                    git_project.url()
+                ),
+            )
+            .file(
+                "src/main.rs",
+                &main_file(r#""{}", dep1::hello()"#, &["dep1"]),
+            )
+            .build()
+    };
+
+    let ws_a = make_ws("ws-a", "foo-a");
+    let ws_b = make_ws("ws-b", "foo-b");
+
+    // Cold cache: both workspaces build the same git dependency at the same
+    // time. Exactly one process should compile it; the other observes the
+    // progress through the per-unit state locks.
+    let mut a = ws_a.cargo("build");
+    let mut b = ws_b.cargo("build");
+    let ra = cargo_test_support::threaded_timeout(600, move || a.run());
+    let rb = cargo_test_support::threaded_timeout(600, move || b.run());
+    drop(ra);
+    drop(rb);
+
+    assert!(ws_a.bin("foo-a").is_file());
+    assert!(ws_b.bin("foo-b").is_file());
+    ws_a
+        .process(&ws_a.bin("foo-a"))
+        .with_stdout_data(str![[r#"
+shared
+
+"#]])
+        .run();
+    ws_b
+        .process(&ws_b.bin("foo-b"))
+        .with_stdout_data(str![[r#"
+shared
+
+"#]])
+        .run();
+
+    // Exactly one completed cache entry for the unit.
+    assert_eq!(cached_rlibs().len(), 1, "exactly one cached rlib expected");
+
+    // A subsequent build in either workspace is fully fresh.
+    ws_a
+        .cargo("build -v")
+        .with_stderr_contains("[FRESH] dep1 v0.5.0 ([ROOTURL]/dep1#[..])")
+        .run();
+}
+
+#[cargo_test]
+fn check_units_shared_across_workspaces() {
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { "checked" }"#,
+            )
+    });
+
+    let make_ws = |name: &str, pkg: &str| {
+        project_in(name)
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                        [package]
+                        name = "{pkg}"
+                        version = "0.5.0"
+                        edition = "2015"
+
+                        [dependencies.dep1]
+                        git = '{}'
+                    "#,
+                    git_project.url()
+                ),
+            )
+            .file(
+                "src/main.rs",
+                &main_file(r#""{}", dep1::hello()"#, &["dep1"]),
+            )
+            .build()
+    };
+
+    let ws_a = make_ws("ws-a", "foo-a");
+    let ws_b = make_ws("ws-b", "foo-b");
+
+    ws_a
+        .cargo("check")
+        .with_stderr_data(str![[r#"
+[UPDATING] git repository `[ROOTURL]/dep1`
+[LOCKING] 1 package to highest compatible version
+[CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
+[CHECKING] foo-a v0.5.0 ([ROOT]/ws-a/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    // The second workspace reuses the check unit from the cache: only its own
+    // member is checked.
+    ws_b
+        .cargo("check")
+        .with_stderr_data(str![[r#"
+[UPDATING] git repository `[ROOTURL]/dep1`
+[LOCKING] 1 package to highest compatible version
+[CHECKING] foo-b v0.5.0 ([ROOT]/ws-b/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn clean_does_not_touch_cache() {
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { "hello" }"#,
+            )
+    });
+
+    let ws = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                git_project.url()
+            ),
+        )
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
+
+    ws.cargo("build").run();
+    assert_eq!(cached_rlibs().len(), 1);
+
+    ws.cargo("clean").run();
+
+    // The cache is shared across workspaces and intentionally not part of a
+    // single workspace's `cargo clean`.
+    assert_eq!(cached_rlibs().len(), 1, "cargo clean must not touch the cache");
+}

--- a/tests/testsuite/build_cache.rs
+++ b/tests/testsuite/build_cache.rs
@@ -407,8 +407,7 @@ fn check_units_shared_across_workspaces() {
 }
 
 #[cargo_test]
-fn clean_does_not_touch_cache() {
-    let git_project = git::new("dep1", |project| {
+fn clean_does_not_touch_cache() {    let git_project = git::new("dep1", |project| {
         project
             .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
@@ -444,4 +443,164 @@ fn clean_does_not_touch_cache() {
     // The cache is shared across workspaces and intentionally not part of a
     // single workspace's `cargo clean`.
     assert_eq!(cached_rlibs().len(), 1, "cargo clean must not touch the cache");
+}
+
+#[cargo_test]
+fn fresh_despite_cache_entry_rewrite() {
+    // A non-cacheable unit (here the workspace binary) whose dependency is a
+    // cache hit must stay fresh when the shared cache entry's artifacts are
+    // rewritten by another workspace (an mtime bump, not a content change):
+    // the freshness mtime chain is skipped for cacheable dependencies, whose
+    // normalized fingerprint content is the authoritative signal. Without
+    // that, `serde` rebuilt after every cache rewrite even though
+    // `serde_derive` was a fresh cache hit.
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { "hello" }"#,
+            )
+    });
+
+    let ws = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                git_project.url()
+            ),
+        )
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
+
+    ws.cargo("build").run();
+    assert_eq!(cached_rlibs().len(), 1);
+
+    // Simulate the shared cache entry being rewritten by another workspace:
+    // bump the mtimes of every cached artifact. The content is unchanged.
+    let now = std::time::SystemTime::now();
+    for file in collect_files(&build_cache_root()) {
+        std::fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(now))
+            .unwrap();
+    }
+
+    // Both the cached dependency and the workspace binary stay fresh; the
+    // binary still runs.
+    ws.cargo("build -v")
+        .with_stderr_contains("[FRESH] dep1 v0.5.0 ([ROOTURL]/dep1#[..])")
+        .with_stderr_contains("[FRESH] foo v0.5.0 ([ROOT]/foo)")
+        .run();
+    ws.process(&ws.bin("foo"))
+        .with_stdout_data(str![[r#"
+hello
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cacheable_unit_fresh_despite_newer_noncacheable_deps() {
+    // A cacheable unit (dep1, in the build cache) whose dependency (dep2, in
+    // the workspace, has a build script) has newer artifacts must stay fresh,
+    // and so must its dependents: a cacheable unit's fs-status must not adopt
+    // the mtime chain from workspace-local dependencies, whose outputs are
+    // routinely newer than the shared cache entry (the cache is written once
+    // and never refreshed). Otherwise every build dirties the whole chain —
+    // the `serde` case (cacheable `serde_derive` vs workspace `serde_core`).
+    let dep2 = git::new("dep2", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                &format!("{}\nbuild = \"build.rs\"\n", basic_lib_manifest("dep2")),
+            )
+            .file(
+                "build.rs",
+                r#"fn main() { println!("cargo:rerun-if-changed=build.rs"); }"#,
+            )
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { "hello" }"#,
+            )
+    });
+
+    let dep1 = git::new("dep1", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                &format!(
+                    "{}\n[dependencies.dep2]\ngit = '{}'\n",
+                    basic_lib_manifest("dep1"),
+                    dep2.url()
+                ),
+            )
+            .file(
+                "src/lib.rs",
+                r#"pub fn hello() -> &'static str { dep2::hello() }"#,
+            )
+    });
+
+    let ws = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.5.0"
+                    edition = "2015"
+
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
+                dep1.url()
+            ),
+        )
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
+
+    ws.cargo("build").run();
+    assert_eq!(cached_rlibs().len(), 1, "dep1 is cached, dep2 is not");
+
+    // Make dep2's workspace artifacts newer than dep1's cache entry (as
+    // happens whenever dep2 rebuilds in the workspace after the cache was
+    // written).
+    let now = std::time::SystemTime::now();
+    for file in collect_files(&paths::root().join("foo/target")) {
+        if file.extension().is_some_and(|e| {
+            matches!(e.to_str(), Some("rlib" | "rmeta" | "so" | "d"))
+        }) {
+            std::fs::File::options()
+                .write(true)
+                .open(&file)
+                .unwrap()
+                .set_times(std::fs::FileTimes::new().set_modified(now))
+                .unwrap();
+        }
+    }
+
+    // dep1 stays fresh (its fs-status ignores dep2's newer mtimes), and so
+    // does foo.
+    ws.cargo("build -v")
+        .with_stderr_contains("[FRESH] dep1 v0.5.0 ([ROOTURL]/dep1#[..])")
+        .with_stderr_contains("[FRESH] foo v0.5.0 ([ROOT]/foo)")
+        .run();
+    ws.process(&ws.bin("foo"))
+        .with_stdout_data(str![[r#"
+hello
+
+"#]])
+        .run();
 }

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -714,13 +714,6 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/bar-[HASH].d
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rlib
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rmeta
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/dep-lib-bar
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/lib-bar
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/lib-bar.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo

--- a/tests/testsuite/build_dir_fine_grain_locking.rs
+++ b/tests/testsuite/build_dir_fine_grain_locking.rs
@@ -731,20 +731,12 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/bar-[HASH].d
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rlib
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rmeta
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/dep-lib-bar
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/lib-bar
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/lib-bar.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/bar/[HASH]/.lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 
 "#]]);

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -418,7 +418,7 @@ fn clean_git() {
     p.cargo("build").run();
     p.cargo("clean -p dep")
         .with_stderr_data(str![[r#"
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[REMOVED] 0 files
 
 "#]])
         .run();
@@ -449,7 +449,7 @@ fn registry() {
     p.cargo("build").run();
     p.cargo("clean -p bar")
         .with_stderr_data(str![[r#"
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[REMOVED] 0 files
 
 "#]])
         .run();
@@ -479,8 +479,7 @@ fn clean_verbose() {
     p.cargo("build").run();
     p.cargo("clean -p bar --verbose")
         .with_stderr_data(str![[r#"
-[REMOVING] [ROOT]/foo/target/debug/build/bar
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[REMOVED] 0 files
 
 "#]])
         .run();
@@ -680,7 +679,7 @@ fn clean_spec_version() {
     p.cargo("clean -p bar:0.1.0")
         .with_stderr_data(str![[r#"
 [WARNING] version qualifier in `-p bar:0.1.0` is ignored, cleaning all versions of `bar` found
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[REMOVED] 0 files
 
 "#]])
         .run();
@@ -735,7 +734,7 @@ fn clean_spec_partial_version() {
     p.cargo("clean -p bar:0.1")
         .with_stderr_data(str![[r#"
 [WARNING] version qualifier in `-p bar:0.1` is ignored, cleaning all versions of `bar` found
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[REMOVED] 0 files
 
 "#]])
         .run();
@@ -790,7 +789,7 @@ fn clean_spec_partial_version_ambiguous() {
     p.cargo("clean -p bar:0")
         .with_stderr_data(str![[r#"
 [WARNING] version qualifier in `-p bar:0` is ignored, cleaning all versions of `bar` found
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[REMOVED] 0 files
 
 "#]])
         .run();

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -254,6 +254,9 @@ fn relative_depinfo_paths_ws() {
         .build();
 
     let host = rustc_host();
+    // Cacheable registry dependencies are built into the build cache, so
+    // their paths in dep-info files are absolute cache paths.
+    let cache = paths::cargo_home().join("build-cache");
     p.cargo("build -Z binary-dep-depinfo --target")
         .arg(&host)
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
@@ -269,7 +272,10 @@ fn relative_depinfo_paths_ws() {
         "target/debug/build/pm/*/fingerprint/dep-lib-pm",
         &[
             (0, "src/lib.rs"),
-            (1, "debug/build/pmdep/*/out/libpmdep-*.rlib"),
+            (
+                1,
+                &cache.join("pmdep/*/out/libpmdep-*.rlib").to_str().unwrap(),
+            ),
         ],
     );
 
@@ -289,7 +295,7 @@ fn relative_depinfo_paths_ws() {
             (1, &format!("{}/debug/build/bar/*/out/libbar-*.rlib", host)),
             (
                 1,
-                &format!("{}/debug/build/regdep/*/out/libregdep-*.rlib", host),
+                &cache.join("regdep/*/out/libregdep-*.rlib").to_str().unwrap(),
             ),
         ],
     );
@@ -299,7 +305,7 @@ fn relative_depinfo_paths_ws() {
         "target/debug/build/foo/*/fingerprint/dep-build-script-build-script-build",
         &[
             (0, "build.rs"),
-            (1, "debug/build/bdep/*/out/libbdep-*.rlib"),
+            (1, &cache.join("bdep/*/out/libbdep-*.rlib").to_str().unwrap()),
         ],
     );
 
@@ -403,12 +409,19 @@ fn relative_depinfo_paths_no_ws() {
 "#]])
         .run();
 
+    // Cacheable registry dependencies are built into the build cache, so
+    // their paths in dep-info files are absolute cache paths.
+    let cache = paths::cargo_home().join("build-cache");
+
     assert_deps_contains(
         &p,
         "target/debug/build/pm/*/fingerprint/dep-lib-pm",
         &[
             (0, "src/lib.rs"),
-            (1, "debug/build/pmdep/*/out/libpmdep-*.rlib"),
+            (
+                1,
+                &cache.join("pmdep/*/out/libpmdep-*.rlib").to_str().unwrap(),
+            ),
         ],
     );
 
@@ -426,7 +439,7 @@ fn relative_depinfo_paths_no_ws() {
                 ),
             ),
             (1, "debug/build/bar/*/out/libbar-*.rlib"),
-            (1, "debug/build/regdep/*/out/libregdep-*.rlib"),
+            (1, &cache.join("regdep/*/out/libregdep-*.rlib").to_str().unwrap()),
         ],
     );
 
@@ -435,7 +448,7 @@ fn relative_depinfo_paths_no_ws() {
         "target/debug/build/foo/*/fingerprint/dep-build-script-build-script-build",
         &[
             (0, "build.rs"),
-            (1, "debug/build/bdep/*/out/libbdep-*.rlib"),
+            (1, &cache.join("bdep/*/out/libbdep-*.rlib").to_str().unwrap()),
         ],
     );
 
@@ -473,9 +486,12 @@ fn reg_dep_source_not_tracked() {
 
     p.cargo("check").run();
 
+    // The registry dependency is cacheable, so its dep-info lives in the
+    // build cache rather than the workspace target directory.
+    let dep_info = paths::cargo_home().join("build-cache/regdep/*/fingerprint/dep-lib-regdep");
     assert_deps(
         &p,
-        "target/debug/build/regdep/*/fingerprint/dep-lib-regdep",
+        dep_info.to_str().unwrap(),
         |info_path, entries| {
             for (kind, path) in entries {
                 if *kind == 1 {
@@ -526,7 +542,13 @@ fn canonical_path() {
         "target/debug/build/foo/*/fingerprint/dep-lib-foo",
         &[
             (0, "src/lib.rs"),
-            (1, "debug/build/regdep/*/out/libregdep-*.rmeta"),
+            (
+                1,
+                &paths::cargo_home()
+                    .join("build-cache/regdep/*/out/libregdep-*.rmeta")
+                    .to_str()
+                    .unwrap(),
+            ),
         ],
     );
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -238,24 +238,28 @@ common
         .run();
     p.cargo("run --features dep1")
         .with_stdout_data(str![[r#"
+build cache: `common` common is fresh (hit [ROOT]/home/.cargo/build-cache/common/025e0bb88962c973)
 dep1
 
 "#]])
         .run();
     p.cargo("run --features foo1")
         .with_stdout_data(str![[r#"
+build cache: `common` common is fresh (hit [ROOT]/home/.cargo/build-cache/common/025e0bb88962c973)
 foo1
 
 "#]])
         .run();
     p.cargo("run --features dep2")
         .with_stdout_data(str![[r#"
+build cache: `common` common is fresh (hit [ROOT]/home/.cargo/build-cache/common/025e0bb88962c973)
 dep2
 
 "#]])
         .run();
     p.cargo("run --features common")
         .with_stdout_data(str![[r#"
+build cache: `common` common is fresh (hit [ROOT]/home/.cargo/build-cache/common/025e0bb88962c973)
 common
 
 "#]])
@@ -1139,6 +1143,8 @@ it is true
     switch_to_resolver_2(&p);
     p.cargo("run")
         .with_stdout_data(str![[r#"
+build cache: `pm` pm is fresh (hit [ROOT]/home/.cargo/build-cache/pm/e40974656c9effb0)
+build cache: `common` common is fresh (hit [ROOT]/home/.cargo/build-cache/common/42b63cb09c8fd064)
 it is false
 
 "#]])
@@ -2696,6 +2702,7 @@ it works
 
 "#]])
         .with_stdout_data(str![[r#"
+build cache: `dep` dep is fresh (hit [ROOT]/home/.cargo/build-cache/dep/ae78596e3cc69400)
 it works
 
 "#]])

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2260,10 +2260,6 @@ fn minimal_download() {
 [DOWNLOADED] normal v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] build_dep_pm v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] build_dep v1.0.0 (registry `dummy-registry`)
-[COMPILING] build_dep_pm v1.0.0
-[COMPILING] build_dep v1.0.0
-[CHECKING] normal_pm v1.0.0
-[CHECKING] normal v1.0.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2284,8 +2280,6 @@ fn minimal_download() {
 [DOWNLOADED] dev_dep v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] build_dep_pm v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] build_dep v1.0.0 (registry `dummy-registry`)
-[COMPILING] build_dep_pm v1.0.0
-[COMPILING] build_dep v1.0.0
 [COMPILING] normal_pm v1.0.0
 [COMPILING] normal v1.0.0
 [COMPILING] dev_dep v1.0.0

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1678,10 +1678,10 @@ fn bust_patched_dep() {
 [DIRTY] registry1 v0.1.0 ([ROOT]/foo/reg1new): the file `reg1new/src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] registry1 v0.1.0 ([ROOT]/foo/reg1new)
 [RUNNING] `rustc --crate-name registry1 [..]
-[DIRTY] registry2 v0.1.0: the dependency `registry1` was rebuilt
+[DIRTY] registry2 v0.1.0: info of dependency `registry1` changed
 [COMPILING] registry2 v0.1.0
 [RUNNING] `rustc --crate-name registry2 [..]
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency `registry2` was rebuilt
+[DIRTY] foo v0.0.1 ([ROOT]/foo): info of dependency `registry2` changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -1708,10 +1708,10 @@ fn bust_patched_dep() {
 [DIRTY] registry1 v0.1.0 ([ROOT]/foo/reg1new): file size changed (0 != 11) for `reg1new/src/lib.rs`
 [COMPILING] registry1 v0.1.0 ([ROOT]/foo/reg1new)
 [RUNNING] `rustc --crate-name registry1 [..]
-[DIRTY] registry2 v0.1.0: the dependency `registry1` was rebuilt
+[DIRTY] registry2 v0.1.0: info of dependency `registry1` changed
 [COMPILING] registry2 v0.1.0
 [RUNNING] `rustc --crate-name registry2 [..]
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency `registry2` was rebuilt
+[DIRTY] foo v0.0.1 ([ROOT]/foo): info of dependency `registry2` changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -10,7 +10,7 @@ use crate::prelude::*;
 use cargo_test_support::assert_deps_contains;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{
-    basic_lib_manifest, basic_manifest, project, rustc_host, rustc_host_env, str,
+    basic_lib_manifest, basic_manifest, paths, project, rustc_host, rustc_host_env, str,
 };
 
 use super::death;
@@ -187,7 +187,10 @@ fn binary_depinfo_correctly_encoded() {
             (1, &format!("{}/debug/build/bar/*/out/libbar-*.rlib", host)),
             (
                 1,
-                &format!("{}/debug/build/regdep/*/out/libregdep-*.rlib", host),
+                &paths::cargo_home()
+                    .join("build-cache/regdep/*/out/libregdep-*.rlib")
+                    .to_str()
+                    .unwrap(),
             ),
         ],
     );

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -1278,7 +1278,6 @@ fn package_cache_lock_during_build() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
    [..]s DEBUG gc: unable to acquire mutate lock, auto gc disabled
-[CHECKING] bar v1.0.0
 [CHECKING] foo2 v0.1.0 ([ROOT]/foo2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -12,6 +12,7 @@ mod bench;
 mod binary_name;
 mod build;
 mod build_analysis;
+mod build_cache;
 mod build_dir;
 mod build_dir_fine_grain_locking;
 mod build_dir_legacy;

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -271,6 +271,7 @@ fn main(){
 
 "#]])
         .with_stdout_data(str![[r#"
+build cache: `present_dep` present_dep is fresh (hit [ROOT]/home/.cargo/build-cache/present_dep/c6965f549ee33889)
 1.2.3
 
 "#]])

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -148,7 +148,6 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
     p2.cargo("check --offline")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[CHECKING] present_dep v1.2.3
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -266,7 +265,6 @@ fn main(){
     p2.cargo("run --offline")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
@@ -703,7 +701,6 @@ fn main(){
     p2.cargo("build --offline")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[COMPILING] present_dep v1.2.9
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -726,7 +723,6 @@ fn main(){
 
     p2.cargo("build --offline")
         .with_stderr_data(str![[r#"
-[COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -5807,7 +5807,9 @@ fn workspace_with_local_deps() {
 
     p.cargo("package")
         .replace_crates_io(crates_io.index_url())
-        .with_stdout_data("")
+        .with_stdout_data(str![[r#"
+build cache: `level3` level3 is fresh (hit [ROOT]/home/.cargo/build-cache/level3/[..]
+"#]])
         .with_stderr_data(str![[r#"
 [PACKAGING] level3 v0.0.1 ([ROOT]/foo/level3)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -43,7 +43,6 @@ fn simple_http() {
 
 "#]],
         str![[r#"
-[CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -65,7 +64,6 @@ fn simple_git() {
 
 "#]],
         str![[r#"
-[CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1698,7 +1696,6 @@ fn update_publish_then_update_http() {
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.1 (registry `dummy-registry`)
-[COMPILING] a v0.1.1
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1711,7 +1708,6 @@ fn update_publish_then_update_git() {
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.1 (registry `dummy-registry`)
-[COMPILING] a v0.1.1
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4545,7 +4541,6 @@ fn differ_only_by_metadata() {
     p.cargo("clean").run();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[CHECKING] baz v0.0.1+b
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -282,7 +282,7 @@ fn can_run_doc_tests() {
     foo.cargo("test -v").with_stderr_data(str![[r#"
 ...
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test src/lib.rs [..] --extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib[..] --extern baz=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib [..]`
+[RUNNING] `rustdoc [..]--test src/lib.rs [..] --extern bar=[ROOT]/home/.cargo/build-cache/bar/[HASH]/out/libbar-[HASH].rlib[..] --extern baz=[ROOT]/home/.cargo/build-cache/bar/[HASH]/out/libbar-[HASH].rlib [..]`
 
 "#]]).run();
 }

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -1136,7 +1136,10 @@ fn overriding_nonexistent_no_spurious() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
-        .with_stdout_data("")
+        .with_stdout_data(str![[r#"
+build cache: `bar` bar is fresh (hit [ROOT]/home/.cargo/build-cache/bar/[..]
+build cache: `baz` baz is fresh (hit [ROOT]/home/.cargo/build-cache/baz/[..]
+"#]])
         .run();
 }
 

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -225,7 +225,6 @@ fn optional_cli_syntax() {
     // Builds bar.
     p.cargo("check --features bar?/feat,bar")
         .with_stderr_data(str![[r#"
-[CHECKING] bar v1.0.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
# LLM DUMP from prototype

# DEV_LOG: Cross-workspace build cache

Working log of design decisions, discovered issues, and fixes while building
the `$CARGO_HOME/build-cache` feature. This is a PoC to learn potential design
issues, so observations are recorded as they are found.

## Status

- [x] Baseline: understand existing POC (`caching poc` commit) and Cargo internals
- [x] Design locking protocol
- [x] Path routing for cacheable units
- [x] Fingerprint/freshness rework
- [x] Locking implementation
- [x] Cross-workspace / concurrency tests (manual)
- [x] Crash recovery test (manual)
- [x] Full test-suite pass (4375/4376 runnable; 1 environment-only failure)
- [x] Tests in the cargo testsuite

## Existing POC (commit 247c74dc1): findings

The prior commit added a first cut. Key observations:

1. `Unit::is_cacheable()` was `!is_local && !custom_build && !is_bin`. Problems:
   - Registry crates **with build scripts** were marked cacheable, but their
     `lib` unit is compiled with workspace-local env vars / `OUT_DIR` baked in.
     Now excluded via `pkg.has_custom_build()`.
   - Doc units were cacheable per the filter but their `output_dir` is the
     workspace `doc/` dir. Now excluded.
   - Test/bench/artifact-dep units are now excluded too.

2. The POC's freshness shortcut (`fingerprint file exists → fresh`) was broken
   in a subtle way: **the fingerprint's *content* encodes identity that the
   unit hash does not.** In particular the git revision is *not* part of the
   unit hash (upstream `SourceId::stable_hash` deliberately excludes
   `precise`), and cargo detects git rev changes via the checkout directory
   path, which shows up as `DirtyReason::PathToSourceChanged` in the
   fingerprint. A pure existence check therefore silently reused the stale
   artifact after a git rev bump, and the binary kept printing the old value.
   **Fixed**: cacheable units are fresh only when the stored fingerprint hash
   matches the computed one (content check). The mtime/`fs_status` part of the
   normal comparison is intentionally skipped: cache artifacts are immutable,
   so mtime changes alone (e.g. the same unit rebuilt byte-identically by
   another workspace) must not invalidate them; every *real* change (rev,
   version, features, flags) shows up in the hash.

3. The POC filtered cacheable dependencies out of `calculate_normal`'s
   fingerprint dep list. That broke **dependency-change propagation to
   non-cacheable dependents**: a binary depending on a git crate was not
   relinked after a rev bump (the dep fingerprint was dropped, so the bin's
   fingerprint hash never changed). **Fixed**: the filter is removed. The
   original reason for it (the `dep_info.strip_prefix(build_root).unwrap()`
   panic for cacheable dep-infos, which live outside the workspace build
   root) is fixed properly: cacheable units now use
   `LocalFingerprint::Precalculated(pkg_fingerprint)` instead of
   `CheckDepInfo`. `calculate_run_custom_build` had the same filter issue and
   the same fix.

4. The abandoned move-based approach (FIXME in `compile()`): correct to
   abandon. With pipelining, consumers read `.rmeta` from the workspace path
   mid-build; moving the directory breaks those reads. Artifacts are born in
   the cache (PLAN.md requirement 4).

5. Debug `println!`s in `fingerprint/dep_info.rs` removed.

6. `-Zbuild-dir-new-layout` is **stabilized** in this tree (1.100) and on by
   default; the legacy layout is only reachable through the temporary
   `__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT` opt-out. The cache is
   gated on the effective new-layout setting (`CompilationFiles::is_cacheable`
   requires `cli_unstable().build_dir_new_layout`), matching PLAN.md's "always
   assume `-Zbuild-dir-new-layout`": legacy-layout invocations never use the
   cache and keep the old workspace behavior (verified by the
   `clean_legacy_layout` / `build_dir_legacy` test modules passing unchanged).

## Design decisions

### Where cacheable units live

`$CARGO_HOME/build-cache/$pkgname/$METADATA/` mirroring the new layout:

```
$CARGO_HOME/build-cache/
  $pkgname/
    $hash/
      out/          # rustc artifacts (replaces deps/)
      fingerprint/  # fingerprint files (hash + .json + dep-info + output cache)
      incremental/  # per-unit incremental data (see "incremental" finding)
      .rmeta.lock   # state lock: rmeta availability
      .rlib.lock    # state lock: full completion
      .lock         # fine-grain locking compatibility (unused by cache protocol)
```

Path routing funnels through `CompilationFiles`: `deps_dir`, `output_dir`,
`fingerprint_dir`, `host_deps`, `build_unit_lock`, and `incremental_dir`
switch on `unit.is_cacheable()`. `pkg_dir` (`$pkgname/$hash`) is stable across
workspaces because the unit hash covers pkg id (registry/git sources hash
independent of workspace root), features, profile, mode, compile kind, rustc
version, and rustflags (minus remap-path-prefix).

### Freshness

Cacheable units use the **normal fingerprint comparison** (hash match plus
filesystem status), like any other unit. The hash match catches identity
changes that are not part of the unit hash; the filesystem-status check
catches changes to non-cacheable dependencies (path patches) and to
dep-info-tracked inputs (env vars under `-Zrustdoc-depinfo`). The fingerprint
file is written after artifacts complete; a unit is reusable when the stored
fingerprint matches the freshly computed one. The artifacts stay effectively
immutable: nothing rebuilds them unless one of these conditions fires.

### Locking protocol (per build unit, two state locks)

flock primitives; two lock files per cacheable unit encode state:

- `.rmeta.lock`: exclusive while compiling until rustc reports the `.rmeta`
  artifact (rustc writes it fully before the artifact notification), then
  shared.
- `.rlib.lock`: exclusive while compiling; shared only after the fingerprint
  is persisted.

Roles (see `src/compiler/cache.rs`):

- **Builder**: shared→exclusive both locks (after releasing shared and
  re-acquiring, with a fingerprint double-check), compiles, downgrades
  `.rmeta.lock` to shared on the rmeta notification (unblocking remote
  pipelined dependents), then downgrades `.rlib.lock` to shared after the
  fingerprint write.
- **Waiter**: takes shared `.rmeta.lock` (blocks until rmeta ready / complete
  / builder crash), then detects an active builder via a non-blocking shared
  `.rlib.lock` attempt. If a builder is active and the unit was never built
  (cold cache), it signals `rmeta_produced` early so its own dependents
  pipeline against the metadata; it then blocks on shared `.rlib.lock`.
  Missing fingerprint after that → the builder crashed → the waiter takes over.

Key ordering invariants:
- fingerprint write happens before `.rlib.lock` is released to shared;
- all lock acquisition is in a fixed order (`.rmeta.lock` before
  `.rlib.lock`), and contenders **release their shared locks before trying
  the exclusive upgrade**, so the multi-lock protocol cannot deadlock (a
  blocking SH→EX conversion drops the old lock while waiting, which would
  otherwise allow lock-order cycles between contenders);
- locks are held (shared) until the end of the build, matching the existing
  fine-grain-locking policy, which also makes crash recovery safe.

### `rmeta_produced` idempotence

`JobState::rmeta_produced` now only pushes `Message::Finish(Metadata)` when it
flips `rmeta_required` from true to false. The dependency queue's `finish`
asserts the edge is still present, so a second Metadata finish would panic;
the waiter-then-builder crash path can reach `rmeta_produced` twice.

## Findings during development

1. **Git rev changes keep the same unit hash.** `SourceId::stable_hash`
   excludes the git `precise` by design. For the cache this is not just an
   efficiency problem: two Cargo processes building **different revisions** of
   the same git URL concurrently collide in one cache directory and race
   (cargo deletes the stale rlib before recompiling, so a concurrent linker
   can observe a missing rlib, reproduced by
   `concurrent::git_same_branch_different_revs`). **Fixed**: `compute_metadata`
   now hashes the git precise into the unit hash, so each revision maps to its
   own cache entry and the "units are immutable" premise of the design is
   actually true. Tradeoff: revision changes accumulate cache entries (old
   ones orphaned); there is no cache GC in the PoC.

2. **Path patches of registry crates need mtime-based invalidation.** A
   cacheable registry crate can depend on a *patched* (path) crate. Editing
   the patch changes no hash (mtimes only), so a content-only freshness check
   kept the dependent fresh (`freshness::bust_patched_dep`). **Fixed**: the
   freshness check for cacheable units is the normal fingerprint comparison
   (hash match *and* filesystem-status up-to-date), exactly like upstream.
   The filesystem-status check may cause a conservative rebuild when a cache
   entry is rebuilt byte-identically by another workspace (newer mtimes),
   correct, rare, and it converges.

3. **Dep-info based env/source tracking must be preserved.** The initial
   `Precalculated` local fingerprint for cacheable units dropped the
   dep-info's `# env-dep:` tracking, so `-Zrustdoc-depinfo` (and
   `-Zbinary-dep-depinfo`) no longer invalidated cacheable check units when
   the environment changed (`doc::rebuild_tracks_env_in_dep`). **Fixed**:
   cacheable units keep `LocalFingerprint::CheckDepInfo`, storing the
   **absolute** dep-info path (the cache is not under the workspace build
   root; `build_root.join(abs)` is a no-op for absolute paths, and cache
   fingerprints are machine-local anyway).

4. **`rmeta_produced` must stay observable.** Guarding the
   `Message::Finish(Metadata)` send on `rmeta_required` suppressed the
   `unit-rmeta-finished` timing event recorded by `-Zbuild-analysis` when no
   dependency needed the metadata edge. **Fixed**: a dedicated `rmeta_sent`
   cell makes the method idempotent (protecting the dependency queue from a
   double `finish`) without suppressing the first message.

5. **The fingerprint directory must exist during compilation.** The POC
   skipped creating it for cacheable units, but the message-cache file is
   created while rustc runs, before the fingerprint is written
   (`build::rustc_wrapper_relative`). **Fixed**: `prepare_init` creates it for
   all units.

6. **Incremental compilation is never used for cacheable units.** Cargo forces
   `profile.incremental = false` for non-local packages, so the per-unit
   `incremental/` directory in the cache is inert today. Kept as defensive
   routing.

7. **Worker threads cannot print "Blocking" lock messages.** `Work` closures
   are `'static`, so the cache locks are acquired silently. The existing
   fine-grain locking avoids this by acquiring locks on the main thread.

8. **flock SH→EX conversion drops the old lock while blocked.** Fixed by
   releasing all shared locks before the exclusive acquisition.

9. **Torn-read race on crash recovery after rmeta-ready (accepted).** A
   builder crash after rmeta-ready can let a waiter pipeline against the
   orphaned rmeta that the waiter's own takeover rebuild rewrites. Rewrites
   are byte-identical in practice; documented in `cache.rs`. Pipelining is
   suppressed when the fingerprint *exists* but mismatches (identity rebuild).

10. **Test-harness footgun**: `(cmd1) (cmd2)` runs subshells sequentially;
    concurrent builds need `&` + `wait`.

## Verification performed (manual)

- Cold build of a git dependency compiles into `$CARGO_HOME/build-cache` and a
  second workspace reuses it without invoking rustc; its binary links against
  the cached rlib and runs.
- `cargo check` units get their own cache entries (rmeta-only) and are reused
  across workspaces.
- Two concurrent cargos, cold cache: exactly one rustc invocation for the
  shared unit (counted in `-vv` logs), the waiter's lib-dependent started
  ~3.4s before the builder's unit completed (cross-process pipelining).
- Warm concurrent rerun: both builds fully fresh in ~40ms.
- Builder killed (SIGKILL) mid-compile leaves rmeta + lock files but no rlib
  and no fingerprint; the next build detects the missing/mismatched
  fingerprint, takes over, completes the unit; the other workspace then
  reuses it.
- Git rev bump (`cargo update`): the new revision gets its own cache entry and
  is compiled; dependents relink (binary output changed); the other workspace
  reuses the new entry.
- Packages with `build.rs` are excluded: built into the workspace, no
  build-cache dir created, build-script env vars work.
- `cargo doc` and `cargo test` unaffected.

11. **Read-only `$CARGO_HOME` must disable the cache, not fail the build.**
    `registry::readonly_registry_still_works_*` chmods `$CARGO_HOME` read-only
    and expects `cargo check` to succeed (deps already fetched). The cache's
    first write (lock file creation) failed with EACCES. **Fixed**: `Layout`
    probes `$CARGO_HOME/build-cache` writability at layout time; when
    un-writable, the cache is disabled for the whole invocation and cacheable
    units fall back to the workspace build directory (`CompilationFiles`
    routes through `is_cacheable() = cache_enabled && unit.is_cacheable()`).

12. **LockManager must not block on `flock` while holding its internal lock
    table.** `concurrent::multiple_registry_fetches` deadlocked
    intermittently: a job thread blocked on a cache `flock` while holding the
    LockManager's `RwLock`, serializing every other lock operation in the
    process, including the operations the lock it was waiting on depended on
    (cross-process cycle). **Fixed**: lock handles are stored as
    `Arc<FileLock>` and every potentially-blocking `flock` call happens after
    dropping the table lock. The test now passes 8/8 consecutive runs (it
    previously hung at a measurable rate).

13. **Cached units depending on build-script crates were invalidated by
    `cargo clean`.** `foo` (serde/syn/serde_derive): after `cargo clean` of
    the workspace target only, `unicode-ident` stayed fresh but `syn` and
    `serde_derive` rebuilt with "info of dependency changed". Root cause: a
    `run-custom-build` unit's `local` fingerprint switches between the
    whole-crate `Precalculated` form (when the previous run's output is
    missing) and the `RerunIfChanged`/`RerunIfEnvChanged` form (when it is
    present). A cacheable unit's *stored* fingerprint (written after the
    build, with the `RerunIf*` state) never matched the *plan-time* fingerprint
    computed after a clean (which sees the `Precalculated` state), a
    byte-identical dependency rebuild invalidated the entry.
    **Fixed**: `Fingerprint::deep_clone` + a normalization pass applied in
    `calculate()` to cacheable units' fingerprints: dependency `local`
    fingerprints of `run-custom-build` and local (path) units are replaced
    (recursively) by the content-based `Precalculated(pkg_fingerprint)` form.
    Registry/git build scripts are immutable, so the `rerun-if-*` bookkeeping
    adds no information; local deps' package fingerprints are mtime-based, so
    path patches still invalidate (verified by `freshness::bust_patched_dep`).
    The clone is private to the cacheable fingerprint, so the shared
    fingerprints used for the dependencies' own freshness are untouched. The
    fs-status check for cacheable units is relaxed to ignore dependency
    staleness (`StaleDependency`/`StaleDepFingerprint`: a dependency was
    rebuilt, which content matching already accounts for) while still
    requiring the unit's own outputs (`Stale`/`StaleItem` still rebuild).
    Result: after `cargo clean`, `serde_derive`/`syn`/`unicode-ident` all stay
    fresh and only the non-cacheable build-script crates rebuild (5.5s → 3s
    in the repro). Known limitation (documented): a build script's
    `rerun-if-env-changed` env vars are not part of the normalized content, so
    an env change that alters a build-script crate's output does not
    invalidate *cache hits* of units depending on it (the build-script crate
    itself still rebuilds correctly; only the cached dependent's reuse
    decision is affected).
    Consequence for the testsuite: cacheable units that stay fresh now emit
    the `build cache: \`pkg\` target is fresh (hit …)` diagnostic on stdout
    (feature requested by the user), and dependency-content changes are
    reported as "info of dependency `X` changed" instead of "the dependency
    `X` was rebuilt" (content-based instead of mtime-based). Affected
    snapshots updated: `freshness::bust_patched_dep`,
    `freshness_checksum::bust_patched_dep_checksum`, and the
    exact-stdout assertions in `features2` (3 tests), `offline`,
    `package::workspace_with_local_deps`, `replace::
    overriding_nonexistent_no_spurious`.

14. **Cached units' fs-status mtime chain dirtied dependents forever.** Same
    `foo` repro: two consecutive builds, `serde` (and `foo`) rebuilt every
    time with "the dependency `serde_derive` was rebuilt"
    (`StaleDependency`), even though `serde_derive` was a fresh cache hit.
    Root cause, two layers:
    (a) a cacheable unit's *own* fs-status still ran the mtime chain against
    its dependencies. The shared cache is written once and never refreshed,
    so a cacheable unit's artifacts are almost always *older* than its
    freshly-rebuilt non-cacheable deps (e.g. `serde_derive`'s cache .so vs
    workspace `quote`/`proc-macro2`), its fs-status was permanently
    `StaleDependency`, which every dependent then inherited as
    `StaleDepFingerprint` and rebuilt against forever; and
    (b) even with (a) fixed, a dependent's own mtime comparison against a
    cacheable dep's artifacts fires whenever the shared cache entry was
    rewritten after the dependent last built.
    **Fixed** in `Fingerprint::check_filesystem`: cacheable units skip the
    dependency loop entirely (their normalized fingerprint content is the
    authoritative signal; `Stale`/`StaleItem` for their own outputs still
    rebuild), and non-cacheable units skip the mtime comparison for cacheable
    dependencies. Unit identity comes from `BuildRunner::
    cacheable_unit_indices` (populated in `prepare_units`). Regression tests:
    `build_cache::fresh_despite_cache_entry_rewrite` (cache artifacts bumped
    newer than the workspace) and `build_cache::
    cacheable_unit_fresh_despite_newer_noncacheable_deps` (cacheable unit's
    workspace dep bumped newer than the cache, reproduces the `serde` case
    exactly: fails with `Dirty foo: the dependency dep1 was rebuilt` without
    the fix, passes with it).

16. **`bat` failed with `E0463: can't find crate for indexmap` (in its build
    script): poisoned cache entries from the buggy WIP binary, not a bug in
    the committed code.** The `.cargo-build-test.sh` run failed while
    compiling bat's build script (`build/main.rs`): E0463 for `indexmap` and
    `serde_with`, with `--extern` paths pointing at existing cache artifacts.
    Root cause chain: (1) the unit hash is cargo-binary-independent, so
    entries written by the intermediate WIP binary (the shared-dir routing
    bug during the sccache E0514 investigation, Aug 21 ~20:16) carry the same
    cache dir names (`indexmap/0ddd52494d3fa8e6`) the current binary uses;
    (2) the WIP binary routed the non-cacheable `serde_core` dependency
    against the wrong rlib, so the cached indexmap rlib embeds a
    `serde_core` metadata hash that does not match the current unit graph;
    (3) the freshness check (content-based fingerprints) correctly reports
    fresh, but the artifact-level reference is garbage → rustc reports E0463
    for the direct dep (or E0460 "possibly newer version of crate
    `serde_core`" when the extra `-L` dirs happen to resolve). The current
    binary itself never reproduces this: with a clean `~/.cargo/build-cache`,
    bat builds (25s cold, ~2s warm) and the second build is fully served from
    cache hits. **Remedy: wipe `~/.cargo/build-cache` once after switching
    dev-cargo binaries.** No code change: cargo artifacts are
    forward-compatible across correct cargo versions, so a commit-level cache
    marker would invalidate the cache on every cargo update for no
    correctness gain, and a binary-content marker costs ~100ms+ per
    invocation (prohibitive for the test-suite, which runs cargo thousands of
    times). The poison is only producible by a *buggy* intermediate binary;
    the standard dev remedy is a one-time cache wipe.
